### PR TITLE
Create record with 1-n agents

### DIFF
--- a/invenio_records_marc21/services/components.py
+++ b/invenio_records_marc21/services/components.py
@@ -18,12 +18,14 @@ class AccessComponent(ServiceComponent):
         """Add basic ownership fields to the record."""
         validated_data = data.get("access", {})
         # TODO (Alex): replace with `record.access = ...`
-        validated_data.setdefault("owned_by", [identity.id])
+        if identity.id:
+            validated_data.setdefault("owned_by", [{"user": identity.id}])
         record.update({"access": validated_data})
 
     def update(self, identity, data=None, record=None, **kwargs):
         """Update handler."""
         validated_data = data.get("access", {})
         # TODO (Alex): replace with `record.access = ...`
-        validated_data.setdefault("owned_by", [identity.id])
+        if identity.id:
+            validated_data.setdefault("owned_by", [{"user": identity.id}])
         record.update({"access": validated_data})

--- a/invenio_records_marc21/services/schemas/access.py
+++ b/invenio_records_marc21/services/schemas/access.py
@@ -32,13 +32,17 @@ class AccessConditionSchema(Schema):
     default_link_validity = fields.Integer()
 
 
+class Agent(Schema):
+    """An agent schema."""
+
+    user = fields.Integer(required=True)
+
+
 class AccessSchema(Schema):
     """Access schema."""
 
     metadata = fields.Bool(required=True)
-    owned_by = fields.List(
-        fields.Integer, validate=validate.Length(min=1), required=True
-    )
+    owned_by = fields.List(fields.Nested(Agent))
     access_right = SanitizedUnicode(required=True)
     embargo_date = ISODateString()
     access_condition = fields.Nested(AccessConditionSchema)

--- a/invenio_records_marc21/services/services.py
+++ b/invenio_records_marc21/services/services.py
@@ -66,7 +66,7 @@ class Marc21RecordService(RecordDraftService):
             default_access = {
                 "access": {
                     "metadata": False,
-                    "owned_by": [identity.id],
+                    "owned_by": [{"user": identity.id}],
                     "access_right": "open",
                     "embargo_date": date.today().strftime("%Y-%m-%d"),
                 },

--- a/tests/services/schemas/test_access.py
+++ b/tests/services/schemas/test_access.py
@@ -20,7 +20,7 @@ from .test_utils import assert_raises_messages
 def test_valid_full(vocabulary_clear):
     valid_full = {
         "metadata": False,
-        "owned_by": [1],
+        "owned_by": [{"user": 1}],
         "embargo_date": "2120-10-06",
         "access_right": "open",
         "access_condition": {
@@ -34,7 +34,7 @@ def test_valid_full(vocabulary_clear):
 def test_invalid_access_right(vocabulary_clear):
     invalid_access_right = {
         "metadata": False,
-        "owned_by": [1],
+        "owned_by": [{"user": 1}],
         "access_right": "invalid value",
     }
 
@@ -54,9 +54,22 @@ def test_invalid_access_right(vocabulary_clear):
 @pytest.mark.parametrize(
     "invalid_access,missing_attr",
     [
-        ({"metadata": False, "access_right": "open"}, "owned_by"),
-        ({"metadata": False, "owned_by": [1]}, "access_right"),
-        ({"owned_by": [1], "access_right": "open"}, "metadata"),
+        (
+            {
+                "metadata": False,
+                "access_right": "open",
+                "owned_by": [1],
+            },
+            "owned_by",
+        ),
+        (
+            {"metadata": False, "owned_by": [{"user": 1}]},
+            "access_right",
+        ),
+        (
+            {"owned_by": [{"user": 1}], "access_right": "open"},
+            "metadata",
+        ),
     ],
 )
 def test_invalid(invalid_access, missing_attr):
@@ -64,6 +77,6 @@ def test_invalid(invalid_access, missing_attr):
     with pytest.raises(ValidationError) as e:
         AccessSchema().load(invalid_access)
 
-        error_fields = e.value.messages.keys()
-        assert len(error_fields) == 1
-        assert missing_attr in error_fields
+    error_fields = e.value.messages.keys()
+    assert len(error_fields) == 1
+    assert missing_attr in error_fields

--- a/tests/services/test_create_record.py
+++ b/tests/services/test_create_record.py
@@ -76,7 +76,7 @@ def empty_data():
             "expect": {
                 "access": {
                     "metadata": False,
-                    "owned_by": [1],
+                    "owned_by": [{"user": 1}],
                     "access_right": "open",
                 },
             },
@@ -88,7 +88,7 @@ def empty_data():
             "expect": {
                 "access": {
                     "metadata": False,
-                    "owned_by": [1],
+                    "owned_by": [{"user": 1}],
                     "access_right": "closed",
                 },
             },
@@ -101,7 +101,7 @@ def empty_data():
             "expect": {
                 "access": {
                     "metadata": False,
-                    "owned_by": [1],
+                    "owned_by": [{"user": 1}],
                     "access_right": "embargoed",
                     "embargo_date": (date.today() + timedelta(days=2)).strftime(
                         "%Y-%m-%d"
@@ -117,7 +117,7 @@ def empty_data():
             "expect": {
                 "access": {
                     "metadata": False,
-                    "owned_by": [1],
+                    "owned_by": [{"user": 1}],
                     "access_right": "restricted",
                     "embargo_date": (date.today() + timedelta(days=3)).strftime(
                         "%Y-%m-%d"


### PR DESCRIPTION
Updating access agent schema allow 1-n owned_by of a marc21 record