### PR TITLE
UI for marc21 records

### DIFF
--- a/invenio_records_marc21/config.py
+++ b/invenio_records_marc21/config.py
@@ -13,47 +13,13 @@ from invenio_indexer.api import RecordIndexer
 from invenio_records_rest.utils import allow_all, check_elasticsearch
 from invenio_search import RecordsSearch
 
-RECORDS_REST_ENDPOINTS = {
-    "recid": dict(
-        pid_type="recid",
-        pid_minter="recid",
-        pid_fetcher="recid",
-        default_endpoint_prefix=True,
-        search_class=RecordsSearch,
-        indexer_class=RecordIndexer,
-        search_index="records",
-        search_type=None,
-        record_serializers={
-            "application/json": (
-                "invenio_records_marc21.serializers" ":json_v1_response"
-            ),
-        },
-        search_serializers={
-            "application/json": (
-                "invenio_records_marc21.serializers" ":json_v1_search"
-            ),
-        },
-        record_loaders={
-            "application/json": ("invenio_records_marc21.loaders" ":json_v1"),
-        },
-        list_route="/records/",
-        item_route="/records/<pid(recid):pid_value>",
-        default_media_type="application/json",
-        max_result_window=10000,
-        error_handlers=dict(),
-        # TODO: Redefine these permissions to cover your auth needs
-        create_permission_factory_imp=allow_all,
-        read_permission_factory_imp=check_elasticsearch,
-        update_permission_factory_imp=allow_all,
-        delete_permission_factory_imp=allow_all,
-    ),
-}
+RECORDS_REST_ENDPOINTS = {}
 """REST API for invenio-records-marc21."""
 
 RECORDS_UI_ENDPOINTS = {
-    "recid": {
-        "pid_type": "recid",
-        "route": "/records/<pid_value>",
+    "marcid": {
+        "pid_type": "marcid",
+        "route": "/marc21/<pid_value>",
         "template": "invenio_records_marc21/record.html",
     },
 }

--- a/invenio_records_marc21/ext.py
+++ b/invenio_records_marc21/ext.py
@@ -50,7 +50,7 @@ class InvenioRecordsMARC21(object):
                         app.config[n].update(getattr(config, k))
 
     def init_resource(self, app):
-        """Initialize vocabulary resources."""
+        """Initialize resources."""
         # Records
         self.records_service = Marc21RecordService(
             config=app.config.get(Marc21RecordService.config_name),

--- a/invenio_records_marc21/ext.py
+++ b/invenio_records_marc21/ext.py
@@ -10,6 +10,7 @@
 from __future__ import absolute_import, print_function
 
 from . import config
+from .resources import Marc21DraftResource, Marc21RecordResource
 from .services import Marc21RecordService
 
 
@@ -53,4 +54,15 @@ class InvenioRecordsMARC21(object):
         # Records
         self.records_service = Marc21RecordService(
             config=app.config.get(Marc21RecordService.config_name),
+        )
+
+        self.records_resource = Marc21RecordResource(
+            service=self.records_service,
+            config=app.config.get(Marc21RecordResource.config_name),
+        )
+
+        # Drafts
+        self.drafts_resource = Marc21DraftResource(
+            service=self.records_service,
+            config=app.config.get(Marc21DraftResource.config_name),
         )

--- a/invenio_records_marc21/resources/__init__.py
+++ b/invenio_records_marc21/resources/__init__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Graz University of Technology.
+#
+# Invenio-Records-Marc21 is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+
+"""Invenio Marc21 module to create REST APIs."""
+
+from .resources import Marc21DraftResource, Marc21RecordResource
+
+__all__ = (
+    "Marc21DraftResource",
+    "Marc21RecordResource",
+)

--- a/invenio_records_marc21/resources/config.py
+++ b/invenio_records_marc21/resources/config.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Graz University of Technology.
+#
+# Invenio-Records-Marc21 is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+
+"""Resources configuration."""
+
+from flask_resources.serializers import JSONSerializer
+from invenio_drafts_resources.resources import DraftResourceConfig, RecordResourceConfig
+from invenio_records_resources.resources import RecordResponse
+from invenio_records_resources.resources.records.schemas_links import (
+    ItemLink,
+    LinksSchema,
+    SearchLinksSchema,
+)
+
+from ..serializers.ui import UIJSONSerializer
+
+#
+# Links
+#
+RecordLinks = LinksSchema.create(
+    links={
+        "self": ItemLink(template="/api/marc21/{pid_value}"),
+        "self_html": ItemLink(template="/marc21/{pid_value}"),
+    }
+)
+
+
+DraftLinks = LinksSchema.create(
+    links={
+        "self": ItemLink(template="/api/marc21/{pid_value}/draft"),
+        "self_html": ItemLink(template="/marc21/uploads/{pid_value}"),
+        "publish": ItemLink(
+            template="/api/marc21/{pid_value}/draft/actions/publish",
+            permission="publish",
+        ),
+    }
+)
+
+
+SearchLinks = SearchLinksSchema.create(template="/api/marc21{?params*}")
+
+#
+# Response handlers
+#
+record_serializers = {
+    "application/json": RecordResponse(UIJSONSerializer()),
+    "application/vnd.inveniomarc21.v1+json": RecordResponse(UIJSONSerializer()),
+}
+
+
+#
+# marc21
+#
+class Marc21RecordResourceConfig(RecordResourceConfig):
+    """Record resource configuration."""
+
+    list_route = "/marc21"
+
+    item_route = "/marc21/<pid_value>"
+
+    links_config = {
+        "marc21": RecordLinks,
+        "search": SearchLinks,
+    }
+
+    draft_links_config = {
+        "marc21": DraftLinks,
+    }
+
+    response_handlers = record_serializers
+
+
+#
+# Drafts and draft actions
+#
+class Marc21DraftResourceConfig(DraftResourceConfig):
+    """Draft resource configuration."""
+
+    list_route = "/marc21/<pid_value>/draft"
+
+    item_route = "/marc21/<pid_value>"  # None
+
+    links_config = {"marc21": DraftLinks}

--- a/invenio_records_marc21/resources/resources.py
+++ b/invenio_records_marc21/resources/resources.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Graz University of Technology.
+#
+# Invenio-Records-Marc21 is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Marc21 Record Resource."""
+
+
+from invenio_drafts_resources.resources import RecordResource, DraftResource
+
+from . import config
+
+#
+# Records
+#
+class Marc21RecordResource(RecordResource):
+    """Bibliographic record resource."""
+
+    config_name = "MARC21_RECORDS_RECORD_CONFIG"
+    default_config = config.Marc21RecordResourceConfig
+
+
+#
+# Drafts
+#
+class Marc21DraftResource(DraftResource):
+    """Bibliographic record draft resource."""
+
+    config_name = "MARC21_RECORDS_DRAFT_CONFIG"
+    default_config = config.Marc21DraftResourceConfig

--- a/invenio_records_marc21/resources/resources.py
+++ b/invenio_records_marc21/resources/resources.py
@@ -8,9 +8,10 @@
 """Marc21 Record Resource."""
 
 
-from invenio_drafts_resources.resources import RecordResource, DraftResource
+from invenio_drafts_resources.resources import DraftResource, RecordResource
 
 from . import config
+
 
 #
 # Records

--- a/invenio_records_marc21/serializers/ui/__init__.py
+++ b/invenio_records_marc21/serializers/ui/__init__.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Graz University of Technology.
+#
+# Invenio-Records-Marc21 is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+
+"""Record response serializers."""
+
+from flask_resources.serializers import JSONSerializer
+
+from .schema import UIListSchema, UIObjectSchema
+
+
+class UIJSONSerializer(JSONSerializer):
+    """UI JSON serializer implementation."""
+
+    object_key = "ui"
+    object_schema_cls = UIObjectSchema
+    list_schema_cls = UIListSchema
+
+    #
+    # Dump Python dictionary (obj and list)
+    #
+    def dump_obj(self, obj):
+        """Dump the object with extra information."""
+        obj[self.object_key] = self.object_schema_cls().dump(obj)
+        return obj
+
+    def dump_list(self, obj_list):
+        """Dump the list of objects with extra information."""
+        ctx = {
+            "object_key": self.object_key,
+            "object_schema_cls": self.object_schema_cls,
+        }
+        return self.list_schema_cls(context=ctx).dump(obj_list)
+
+    #
+    # Serialize to  JSON (obj and list)
+    #
+    def serialize_object(self, obj):
+        """Dump the object into a JSON string."""
+        return super().serialize_object(self.dump_obj(obj))
+
+    def serialize_object_list(self, obj_list):
+        """Dump the object list into a JSON string."""
+        return super().serialize_object_list(self.dump_list(obj_list))
+
+    def serialize_object_to_dict(self, obj):
+        """Dump the object into a JSON string."""
+        return self.dump_obj(obj)
+
+    def serialize_object_list_to_dict(self, obj_list):
+        """Dump the object list into a JSON string."""
+        return self.dump_list(obj_list)

--- a/invenio_records_marc21/serializers/ui/schema.py
+++ b/invenio_records_marc21/serializers/ui/schema.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Graz University of Technology.
+#
+# Invenio-Records-Marc21 is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+""" Schema ui. """
+from copy import deepcopy
+from functools import partial
+
+from dojson.contrib.to_marc21 import to_marc21
+from dojson.contrib.to_marc21.utils import dumps
+from marshmallow import INCLUDE, Schema, missing, pre_dump
+from marshmallow.fields import Dict, Method, Nested, Str
+from marshmallow_utils.fields import SanitizedUnicode
+
+
+#
+# Object schema
+#
+class AccessRightSchema(Schema):
+    """Access right vocabulary."""
+
+
+#
+# Object schema
+#
+class MetadataSchema(Schema):
+    """Access right vocabulary."""
+
+    xml = Str(required=False)
+    # json = Dict(required=False)
+
+    @pre_dump
+    def convert_xml(self, data, **kwargs):
+        """Convert json into marc21 xml."""
+        if "json" in data:
+            data["xml"] = dumps(to_marc21.do(data["json"]))
+        return data
+
+
+class UIObjectSchema(Schema):
+    """Schema for dumping extra information for the UI."""
+
+    metadata = Nested(MetadataSchema, attribute="metadata")
+
+    access_right = Nested(AccessRightSchema, attribute="access")
+
+
+#
+# List schema
+class UIListSchema(Schema):
+    """Schema for dumping extra information in the UI."""
+
+    class Meta:
+        """."""
+
+        unknown = INCLUDE
+
+    hits = Method("get_hits")
+    aggregations = Method("get_aggs")
+
+    def get_hits(self, obj_list):
+        """Apply hits transformation."""
+        for obj in obj_list["hits"]["hits"]:
+            obj[self.context["object_key"]] = self.context["object_schema_cls"]().dump(
+                obj
+            )
+        return obj_list["hits"]
+
+    def get_aggs(self, obj_list):
+        """Apply aggregations transformation."""
+        aggs = obj_list.get("aggregations")
+        missing = ""
+        if not aggs:
+            return missing
+
+        for name, agg in aggs.items():
+            vocab = ""
+            if not vocab:
+                continue
+
+            buckets = agg.get("buckets")
+            if buckets:
+                apply_labels(vocab, buckets)
+
+        return aggs
+
+
+def apply_labels(vocab, buckets):
+    """Inject labels in the aggregation buckets.
+
+    :params agg: Current aggregation object.
+    :params vocab: The vocabulary
+    """
+    for b in buckets:
+        b["label"] = vocab.get_title_by_dict(b["key"])
+
+        # Recursively apply to subbuckets
+        for data in b.values():
+            if isinstance(data, dict) and "buckets" in data:
+                apply_labels(vocab, data["buckets"])

--- a/invenio_records_marc21/serializers/ui/schema.py
+++ b/invenio_records_marc21/serializers/ui/schema.py
@@ -7,13 +7,13 @@
 
 """Schema ui."""
 from copy import deepcopy
-from functools import partial
 
 from dojson.contrib.to_marc21 import to_marc21
 from dojson.contrib.to_marc21.utils import dumps
 from marshmallow import INCLUDE, Schema, missing, pre_dump
 from marshmallow.fields import Dict, Method, Nested, Str
-from marshmallow_utils.fields import SanitizedUnicode
+
+from invenio_records_marc21.vocabularies import Vocabularies
 
 
 #
@@ -72,12 +72,11 @@ class UIListSchema(Schema):
     def get_aggs(self, obj_list):
         """Apply aggregations transformation."""
         aggs = obj_list.get("aggregations")
-        missing = ""
         if not aggs:
             return missing
 
         for name, agg in aggs.items():
-            vocab = ""
+            vocab = Vocabularies.get_vocabulary(name)
             if not vocab:
                 continue
 
@@ -94,10 +93,10 @@ def apply_labels(vocab, buckets):
     :params agg: Current aggregation object.
     :params vocab: The vocabulary
     """
-    for b in buckets:
-        b["label"] = vocab.get_title_by_dict(b["key"])
+    for bucket in buckets:
+        bucket["label"] = vocab.get_title_by_dict(bucket["key"])
 
         # Recursively apply to subbuckets
-        for data in b.values():
+        for data in bucket.values():
             if isinstance(data, dict) and "buckets" in data:
                 apply_labels(vocab, data["buckets"])

--- a/invenio_records_marc21/serializers/ui/schema.py
+++ b/invenio_records_marc21/serializers/ui/schema.py
@@ -5,7 +5,7 @@
 # Invenio-Records-Marc21 is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-""" Schema ui. """
+"""Schema ui."""
 from copy import deepcopy
 from functools import partial
 

--- a/invenio_records_marc21/static/templates/invenio_records_marc21/results.html
+++ b/invenio_records_marc21/static/templates/invenio_records_marc21/results.html
@@ -6,7 +6,7 @@
 -->
 
 <div ng-repeat="record in vm.invenioSearchResults.hits.hits track by $index">
-  <h4><a target="_self" ng-href="/records/{{ record.id }}">{{ record.metadata.title }}</a></h4>
+  <h4><a target="_self" ng-href="/marc21/{{ record.id }}">{{ record.metadata.title }}</a></h4>
   <ul class="list-inline">
       <li ng-repeat='contributor in record.metadata.contributors'>
         {{ contributor.name }};

--- a/invenio_records_marc21/views.py
+++ b/invenio_records_marc21/views.py
@@ -25,7 +25,7 @@ this file.
 """
 
 
-def create_records_bp(app):
+def create_records_blueprint(app):
     """Create records blueprint."""
     ext = app.extensions
     return ext["invenio-records-marc21"].records_resource.as_blueprint(
@@ -33,7 +33,7 @@ def create_records_bp(app):
     )
 
 
-def create_drafts_bp(app):
+def create_drafts_blueprint(app):
     """Create drafts blueprint."""
     ext = app.extensions
     return ext["invenio-records-marc21"].drafts_resource.as_blueprint(

--- a/invenio_records_marc21/views.py
+++ b/invenio_records_marc21/views.py
@@ -23,3 +23,16 @@ The sole purpose of this blueprint is to ensure that Invenio can find the
 templates and static files located in the folders of the same names next to
 this file.
 """
+
+
+
+def create_records_bp(app):
+    """Create records blueprint."""
+    ext = app.extensions
+    return ext["invenio-records-marc21"].records_resource.as_blueprint("marc21_records_resource")
+
+
+def create_drafts_bp(app):
+    """Create drafts blueprint."""
+    ext = app.extensions
+    return ext["invenio-records-marc21"].drafts_resource.as_blueprint("marc21_draft_resource")

--- a/invenio_records_marc21/views.py
+++ b/invenio_records_marc21/views.py
@@ -25,14 +25,17 @@ this file.
 """
 
 
-
 def create_records_bp(app):
     """Create records blueprint."""
     ext = app.extensions
-    return ext["invenio-records-marc21"].records_resource.as_blueprint("marc21_records_resource")
+    return ext["invenio-records-marc21"].records_resource.as_blueprint(
+        "marc21_records_resource"
+    )
 
 
 def create_drafts_bp(app):
     """Create drafts blueprint."""
     ext = app.extensions
-    return ext["invenio-records-marc21"].drafts_resource.as_blueprint("marc21_draft_resource")
+    return ext["invenio-records-marc21"].drafts_resource.as_blueprint(
+        "marc21_draft_resource"
+    )

--- a/setup.py
+++ b/setup.py
@@ -53,10 +53,9 @@ setup_requires = [
 install_requires = [
     "invenio-i18n>=1.3.0",
     "dojson>=1.4.0",
-    "idutils>=1.1.7",
-    "invenio-records-rest>=1.4.0,<2.0.0",
-    "invenio-drafts-resources>=0.7.2,<0.10.0",
-    "invenio-vocabularies>=0.1.6,<1.0.0",
+    "invenio-records-rest>=1.5.0,<2.0.0",
+    "invenio-drafts-resources>=0.9.7,<0.10.0",
+    "invenio-vocabularies>=0.3.3,<0.4.0",
 ]
 
 packages = find_packages()

--- a/setup.py
+++ b/setup.py
@@ -92,13 +92,13 @@ setup(
             "invenio_records_marc21 = invenio_records_marc21:InvenioRecordsMARC21",
         ],
         "invenio_base.api_blueprints": [
-            "invenio_records_marc21_record = invenio_records_marc21.views:create_records_bp",
-            "invenio_records_marc21_draft = invenio_records_marc21.views:create_drafts_bp",
+            "invenio_records_marc21_record = invenio_records_marc21.views:create_records_blueprint",
+            "invenio_records_marc21_draft = invenio_records_marc21.views:create_drafts_blueprint",
         ],
         "invenio_base.blueprints": [
             "invenio_records_marc21 = invenio_records_marc21.views:blueprint",
-            "invenio_records_marc21_record = invenio_records_marc21.views:create_records_bp",
-            "invenio_records_marc21_draft = invenio_records_marc21.views:create_drafts_bp",
+            "invenio_records_marc21_record = invenio_records_marc21.views:create_records_blueprint",
+            "invenio_records_marc21_draft = invenio_records_marc21.views:create_drafts_blueprint",
         ],
         "invenio_i18n.translations": [
             "messages = invenio_records_marc21",

--- a/setup.py
+++ b/setup.py
@@ -89,8 +89,17 @@ setup(
         "invenio_base.apps": [
             "invenio_records_marc21 = invenio_records_marc21:InvenioRecordsMARC21",
         ],
+        "invenio_base.api_apps": [
+            "invenio_records_marc21 = invenio_records_marc21:InvenioRecordsMARC21",
+        ],
+        "invenio_base.api_blueprints": [
+            "invenio_records_marc21_record = invenio_records_marc21.views:create_records_bp",
+            "invenio_records_marc21_draft = invenio_records_marc21.views:create_drafts_bp",
+        ],
         "invenio_base.blueprints": [
             "invenio_records_marc21 = invenio_records_marc21.views:blueprint",
+            "invenio_records_marc21_record = invenio_records_marc21.views:create_records_bp",
+            "invenio_records_marc21_draft = invenio_records_marc21.views:create_drafts_bp",
         ],
         "invenio_i18n.translations": [
             "messages = invenio_records_marc21",


### PR DESCRIPTION
**Aim**
It should be possible to display marc21 records in invenio.

 Create records can be listed with: 
`curl -k https://127.0.0.1:5000/api/marc21?prettyprint=1`

It's also given a possibility to search for a specific type of records:
`curl -k https://127.0.0.1:5000/api/marc21?q=open`

To display a specific record:
`https://127.0.0.1:5000/api/marc21/<pid_value>`