### PR TITLE
Marc21 metadata

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -39,5 +39,6 @@ recursive-include invenio_records_marc21 *.xml
 recursive-include invenio_records_marc21 *.py
 recursive-include invenio_records_marc21 *.csv
 recursive-include invenio_records_marc21 *.js
+recursive-include invenio_records_marc21 *.xsd
 recursive-include tests *.py
 recursive-include tests *.json

--- a/invenio_records_marc21/cli.py
+++ b/invenio_records_marc21/cli.py
@@ -18,8 +18,8 @@ from flask_principal import Identity
 from invenio_access import any_user
 
 from .proxies import current_records_marc21
-from .services import Metadata
 from .services.components import AccessStatusEnum
+from .services.record import Marc21Metadata
 
 
 def system_identity():
@@ -56,7 +56,7 @@ def _load_json(filename):
 
 def create_fake_metadata(filename):
     """Create records for demo purposes."""
-    metadata = Metadata()
+    metadata = Marc21Metadata()
     metadata.xml = _load_file(filename)
     metadata_access = fake_access_right()
     data_acces = {

--- a/invenio_records_marc21/services/__init__.py
+++ b/invenio_records_marc21/services/__init__.py
@@ -18,12 +18,10 @@ from .services import (
     Marc21DraftFilesService,
     Marc21RecordFilesService,
     Marc21RecordService,
-    Metadata,
     RecordItem,
 )
 
 __all__ = (
-    "Metadata",
     "Marc21RecordService",
     "Marc21DraftFilesService",
     "Marc21RecordFilesService",

--- a/invenio_records_marc21/services/record/__init__.py
+++ b/invenio_records_marc21/services/record/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Graz University of Technology.
+#
+# Invenio-Records-Marc21 is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+
+"""Marc21 field class."""
+
+from .fields import ControlField, DataField, SubField
+from .metadata import Marc21Metadata
+
+__all__ = (
+    "Marc21Metadata",
+    "ControlField",
+    "DataField",
+    "SubField",
+)

--- a/invenio_records_marc21/services/record/fields/__init__.py
+++ b/invenio_records_marc21/services/record/fields/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Graz University of Technology.
+#
+# Invenio-Records-Marc21 is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+
+"""Marc21 field class."""
+
+from .control import ControlField
+from .data import DataField
+from .leader import LeaderField
+from .sub import SubField
+
+__all__ = (
+    "ControlField",
+    "DataField",
+    "LeaderField",
+    "SubField",
+)

--- a/invenio_records_marc21/services/record/fields/control.py
+++ b/invenio_records_marc21/services/record/fields/control.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Graz University of Technology.
+#
+# Invenio-Records-Marc21 is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Marc21 control field class."""
+
+
+from os import linesep
+
+
+class ControlField(object):
+    """ControlField class representing the controlfield HTML tag in MARC21 XML."""
+
+    def __init__(self, tag: str = "", value: str = ""):
+        """Default constructor of the class."""
+        self.tag = tag
+        self.value = value
+
+    def to_xml_tag(self, tagsep: str = linesep, indent: int = 4) -> str:
+        """Get the Marc21 Controlfield XML tag as string."""
+        controlfield_tag = " " * indent
+        controlfield_tag += f'<controlfield tag="{self.tag}">{self.value}'
+        controlfield_tag += " " * indent
+        controlfield_tag += "</controlfield>"
+        controlfield_tag += tagsep
+        return controlfield_tag

--- a/invenio_records_marc21/services/record/fields/data.py
+++ b/invenio_records_marc21/services/record/fields/data.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Graz University of Technology.
+#
+# Invenio-Records-Marc21 is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Marc21 data field class."""
+
+
+from os import linesep
+
+
+class DataField(object):
+    """DataField class representing the datafield HTML tag in MARC21 XML."""
+
+    def __init__(self, tag: str = "", ind1: str = " ", ind2: str = " "):
+        """Default constructor of the class."""
+        self.tag = tag
+        self.ind1 = ind1
+        self.ind2 = ind2
+        self.subfields = list()
+
+    def to_xml_tag(self, tagsep: str = linesep, indent: int = 4) -> str:
+        """Get the Marc21 Datafield XML tag as string."""
+        datafield_tag = " " * indent
+        datafield_tag += (
+            f'<datafield tag="{self.tag}" ind1="{self.ind1}" ind2="{self.ind2}">'
+        )
+        datafield_tag += tagsep
+        for subfield in self.subfields:
+            datafield_tag += subfield.to_xml_tag(tagsep, indent)
+        datafield_tag += " " * indent
+        datafield_tag += "</datafield>"
+        datafield_tag += tagsep
+        return datafield_tag

--- a/invenio_records_marc21/services/record/fields/leader.py
+++ b/invenio_records_marc21/services/record/fields/leader.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Graz University of Technology.
+#
+# Invenio-Records-Marc21 is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Marc21 leader field class."""
+
+
+from os import linesep
+
+
+class LeaderField(object):
+    """LeaderField class representing the leaderfield HTML tag in MARC21 XML."""
+
+    def __init__(self, **kwargs):
+        """Default constructor of the class."""
+        self.length = kwargs.get("length", "00000")  # 00-04
+        self.status = kwargs.get("status", "n")  # 05
+        self.type = kwargs.get("type", "a")  # 06
+        self.level = kwargs.get("level", "m")  # 07
+        self.control = kwargs.get("control", " ")  # 08
+        self.charset = kwargs.get("charset", "a")  # 09
+
+        self.ind_count = kwargs.get("ind_count", "2")  # 10
+        self.sub_count = kwargs.get("sub_count", "2")  # 11
+        self.address = kwargs.get("address", "00000")  # 12-16
+        self.encoding = kwargs.get("encoding", "z")  # 17
+        self.description = kwargs.get("description", "c")  # 18
+        self.multipart_resource_record_level = kwargs.get(
+            "multipart_resource_record_level", "a"
+        )  # 19
+        self.length_field_position = kwargs.get("length_field_position", "4")  # 20
+        self.length_starting_character_position_portion = kwargs.get(
+            "length_starting_character_position_portion", "5"
+        )  # 21
+        self.length_implementation_defined_portion = kwargs.get(
+            "length_implementation_defined_portion", "0"
+        )  # 22
+        self.undefined = kwargs.get("undefined", "0")  # 23
+
+    def to_xml_tag(self, tagsep: str = linesep, indent: int = 4) -> str:
+        """Get the Marc21 Leaderfield XML tag as string."""
+        leader = " " * indent
+        leader += "<leader>"
+        leader += f"{self.length}{self.status}{self.type}{self.level}{self.control}{self.charset}"
+        leader += f"{self.ind_count}{self.sub_count}{self.address}{self.encoding}{self.description}"
+        leader += f"{self.multipart_resource_record_level}{self.length_field_position}"
+        leader += f"{self.length_starting_character_position_portion}{self.length_implementation_defined_portion}"
+        leader += f"{self.undefined}"
+        leader += "</leader>"
+        leader += tagsep
+        return leader

--- a/invenio_records_marc21/services/record/fields/sub.py
+++ b/invenio_records_marc21/services/record/fields/sub.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Graz University of Technology.
+#
+# Invenio-Records-Marc21 is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Marc21 sub field class."""
+
+
+from os import linesep
+
+
+class SubField(object):
+    """SubField class representing the subfield HTML tag in MARC21 XML."""
+
+    def __init__(self, code: str = "", value: str = ""):
+        """Default constructor of the class."""
+        self.code = code
+        self.value = value
+
+    def to_xml_tag(self, tagsep: str = linesep, indent: int = 4) -> str:
+        """Get the Marc21 Subfield XML tag as string."""
+        subfield_tag = 2 * " " * indent
+        subfield_tag += f'<subfield code="{self.code}">{self.value}'
+        subfield_tag += f"</subfield>"
+        subfield_tag += tagsep
+        return subfield_tag

--- a/invenio_records_marc21/services/record/metadata.py
+++ b/invenio_records_marc21/services/record/metadata.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Graz University of Technology.
+#
+# Invenio-Records-Marc21 is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Marc21 record class."""
+
+from io import StringIO
+from os import linesep
+from os.path import dirname, join
+
+from lxml import etree
+
+from .fields import DataField, LeaderField, SubField
+
+
+class Marc21Metadata(object):
+    """MARC21 Record class to facilitate storage of records in MARC21 format."""
+
+    def __init__(self, leader: LeaderField = LeaderField()):
+        """Default constructor of the class."""
+        self._xml = ""
+        self._json = {}
+        self.leader = leader
+        self.controlfields = list()
+        self.datafields = list()
+
+    @property
+    def json(self):
+        """Metadata json getter method."""
+        return self._json
+
+    @json.setter
+    def json(self, json: dict):
+        """Metadata json setter method."""
+        if not isinstance(json, dict):
+            raise TypeError("json must be from type dict")
+        self._json = json
+
+    @property
+    def xml(self):
+        """Metadata xml getter method."""
+        self._to_string()
+        return self._xml
+
+    @xml.setter
+    def xml(self, xml: str):
+        """Metadata xml setter method."""
+        if not isinstance(xml, str):
+            raise TypeError("xml must be from type str")
+
+        self._to_xml_tree(xml)
+        self._xml = xml
+
+    def _to_xml_tree(self, xml: str):
+        """Xml to internal representation method."""
+        test = etree.parse(StringIO(xml))
+        for element in test.iter():
+            if element.tag == "datafield":
+                self.datafields.append(DataField(**element.attrib))
+            elif element.tag == "subfield":
+                self.datafields[-1].subfields.append(
+                    SubField(**element.attrib, value=element.text)
+                )
+
+    def _to_string(self, tagsep: str = linesep, indent: int = 4) -> str:
+        """Get a pretty-printed XML string of the record."""
+        self._xml = "<?xml version='1.0' ?>"
+        self._xml += '<record xmlns="http://www.loc.gov/MARC21/slim" xsi:schemaLocation="http://www.loc.gov/MARC21/slim schema.xsd" type="Bibliographic" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
+        self._xml += tagsep
+        if self.leader:
+            self._xml += self.leader.to_xml_tag(tagsep, indent)
+        for controlfield in self.controlfields:
+            self._xml += controlfield.to_xml_tag(tagsep, indent)
+        for datafield in self.datafields:
+            self._xml += datafield.to_xml_tag(tagsep, indent)
+        self._xml += "</record>"
+
+    def contains(self, ref_df: DataField, ref_sf: SubField) -> bool:
+        """Return True if record contains reference datafield, which contains reference subfield."""
+        for df in self.datafields:
+            if (
+                df.tag == ref_df.tag and df.ind1 == ref_df.ind1 and df.ind2 == ref_df.ind2
+            ):
+                for sf in df.subfields:
+                    if sf.code == ref_sf.code and sf.value == ref_sf.value:
+                        return True
+        return False
+
+    def add_value(
+        self,
+        tag: str = "",
+        ind1: str = " ",
+        ind2: str = " ",
+        code: str = "",
+        value: str = "",
+    ) -> None:
+        """Add value to record for given datafield and subfield."""
+        datafield = DataField(tag, ind1, ind2)
+        subfield = SubField(code, value)
+        datafield.subfields.append(subfield)
+        self.datafields.append(datafield)
+
+    def add_unique_value(
+        self,
+        tag: str = "",
+        ind1: str = " ",
+        ind2: str = " ",
+        code: str = "",
+        value: str = "",
+    ) -> None:
+        """Add value to record if it doesn't already contain it."""
+        datafield = DataField(tag, ind1, ind2)
+        subfield = SubField(code, value)
+        if not self.contains(datafield, subfield):
+            datafield.subfields.append(subfield)
+            self.datafields.append(datafield)
+
+    def is_valid_marc21_xml_string(self) -> bool:
+        """Validate the record against a Marc21XML Schema."""
+        with open(
+            join(dirname(__file__), "schema", "MARC21slim.xsd"), "r", encoding="utf-8"
+        ) as fp:
+            marc21xml_schema = etree.XMLSchema(etree.parse(fp))
+            marc21xml = etree.parse(StringIO(self.xml))
+            return marc21xml_schema.validate(marc21xml)

--- a/invenio_records_marc21/services/record/metadata.py
+++ b/invenio_records_marc21/services/record/metadata.py
@@ -89,7 +89,7 @@ class Marc21Metadata(object):
                         return True
         return False
 
-    def add_value(
+    def emplace_field(
         self,
         tag: str = "",
         ind1: str = " ",
@@ -103,7 +103,7 @@ class Marc21Metadata(object):
         datafield.subfields.append(subfield)
         self.datafields.append(datafield)
 
-    def add_unique_value(
+    def emplace_unique_field(
         self,
         tag: str = "",
         ind1: str = " ",

--- a/invenio_records_marc21/services/record/schema/MARC21slim.xsd
+++ b/invenio_records_marc21/services/record/schema/MARC21slim.xsd
@@ -1,0 +1,150 @@
+<?xml version="1.0"?>
+<xsd:schema targetNamespace="http://www.loc.gov/MARC21/slim" xmlns="http://www.loc.gov/MARC21/slim" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" xml:lang="en">
+  <xsd:annotation>
+    <xsd:documentation>
+			MARCXML: The MARC 21 XML Schema
+			Prepared by Corey Keith
+			
+				May 21, 2002 - Version 1.0  - Initial Release
+
+**********************************************
+Changes.
+
+August 4, 2003 - Version 1.1 - 
+Removed import of xml namespace and the use of xml:space="preserve" attributes on the leader and controlfields. 
+                    Whitespace preservation in these subfields is accomplished by the use of xsd:whiteSpace value="preserve"
+
+May 21, 2009  - Version 1.2 - 
+in subfieldcodeDataType  the pattern 
+                          "[\da-z!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?{}_^`~\[\]\\]{1}"
+	changed to:	
+                         "[\dA-Za-z!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?{}_^`~\[\]\\]{1}"
+    i.e "A-Z" added after "[\d" before "a-z"  to allow upper case.  This change is for consistency with the documentation.
+	
+************************************************************
+			This schema supports XML markup of MARC21 records as specified in the MARC documentation (see www.loc.gov).  It allows tags with
+			alphabetics and subfield codes that are symbols, neither of which are as yet used in  the MARC 21 communications formats, but are 
+			allowed by MARC 21 for local data.  The schema accommodates all types of MARC 21 records: bibliographic, holdings, bibliographic 
+			with embedded holdings, authority, classification, and community information.
+		</xsd:documentation>
+  </xsd:annotation>
+  <xsd:element name="record" type="recordType" nillable="true" id="record.e">
+    <xsd:annotation>
+      <xsd:documentation>record is a top level container element for all of the field elements which compose the record</xsd:documentation>
+    </xsd:annotation>
+  </xsd:element>
+  <xsd:element name="collection" type="collectionType" nillable="true" id="collection.e">
+    <xsd:annotation>
+      <xsd:documentation>collection is a top level container element for 0 or many records</xsd:documentation>
+    </xsd:annotation>
+  </xsd:element>
+  <xsd:complexType name="collectionType" id="collection.ct">
+    <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+      <xsd:element ref="record"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="idDataType" use="optional"/>
+  </xsd:complexType>
+  <xsd:complexType name="recordType" id="record.ct">
+    <xsd:sequence minOccurs="0">
+      <xsd:element name="leader" type="leaderFieldType"/>
+      <xsd:element name="controlfield" type="controlFieldType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="datafield" type="dataFieldType" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="type" type="recordTypeType" use="optional"/>
+    <xsd:attribute name="id" type="idDataType" use="optional"/>
+  </xsd:complexType>
+  <xsd:simpleType name="recordTypeType" id="type.st">
+    <xsd:restriction base="xsd:NMTOKEN">
+      <xsd:enumeration value="Bibliographic"/>
+      <xsd:enumeration value="Authority"/>
+      <xsd:enumeration value="Holdings"/>
+      <xsd:enumeration value="Classification"/>
+      <xsd:enumeration value="Community"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="leaderFieldType" id="leader.ct">
+    <xsd:annotation>
+      <xsd:documentation>MARC21 Leader, 24 bytes</xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="leaderDataType">
+        <xsd:attribute name="id" type="idDataType" use="optional"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:simpleType name="leaderDataType" id="leader.st">
+    <xsd:restriction base="xsd:string">
+      <xsd:whiteSpace value="preserve"/>
+      <xsd:pattern value="[\d ]{5}[\dA-Za-z ]{1}[\dA-Za-z]{1}[\dA-Za-z ]{3}(2| )(2| )[\d ]{5}[\dA-Za-z ]{3}(4500|    )"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="controlFieldType" id="controlfield.ct">
+    <xsd:annotation>
+      <xsd:documentation>MARC21 Fields 001-009</xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="controlDataType">
+        <xsd:attribute name="id" type="idDataType" use="optional"/>
+        <xsd:attribute name="tag" type="controltagDataType" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:simpleType name="controlDataType" id="controlfield.st">
+    <xsd:restriction base="xsd:string">
+      <xsd:whiteSpace value="preserve"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="controltagDataType" id="controltag.st">
+    <xsd:restriction base="xsd:string">
+      <xsd:whiteSpace value="preserve"/>
+      <xsd:pattern value="00[1-9A-Za-z]{1}"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="dataFieldType" id="datafield.ct">
+    <xsd:annotation>
+      <xsd:documentation>MARC21 Variable Data Fields 010-999</xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence maxOccurs="unbounded">
+      <xsd:element name="subfield" type="subfieldatafieldType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="idDataType" use="optional"/>
+    <xsd:attribute name="tag" type="tagDataType" use="required"/>
+    <xsd:attribute name="ind1" type="indicatorDataType" use="required"/>
+    <xsd:attribute name="ind2" type="indicatorDataType" use="required"/>
+  </xsd:complexType>
+  <xsd:simpleType name="tagDataType" id="tag.st">
+    <xsd:restriction base="xsd:string">
+      <xsd:whiteSpace value="preserve"/>
+      <xsd:pattern value="(0([1-9A-Z][0-9A-Z])|0([1-9a-z][0-9a-z]))|(([1-9A-Z][0-9A-Z]{2})|([1-9a-z][0-9a-z]{2}))"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="indicatorDataType" id="ind.st">
+    <xsd:restriction base="xsd:string">
+      <xsd:whiteSpace value="preserve"/>
+      <xsd:pattern value="[\da-z ]{1}"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:complexType name="subfieldatafieldType" id="subfield.ct">
+    <xsd:simpleContent>
+      <xsd:extension base="subfieldDataType">
+        <xsd:attribute name="id" type="idDataType" use="optional"/>
+        <xsd:attribute name="code" type="subfieldcodeDataType" use="required"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+  <xsd:simpleType name="subfieldDataType" id="subfield.st">
+    <xsd:restriction base="xsd:string">
+      <xsd:whiteSpace value="preserve"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="subfieldcodeDataType" id="code.st">
+    <xsd:restriction base="xsd:string">
+      <xsd:whiteSpace value="preserve"/>
+      <xsd:pattern value="[\dA-Za-z!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?{}_^`~\[\]\\]{1}"/>
+      <!-- "A-Z" added after "\d" May 21, 2009 -->
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="idDataType" id="id.st">
+    <xsd:restriction base="xsd:ID"/>
+  </xsd:simpleType>
+</xsd:schema>

--- a/invenio_records_marc21/services/services.py
+++ b/invenio_records_marc21/services/services.py
@@ -19,37 +19,7 @@ from .config import (
     Marc21RecordFilesServiceConfig,
     Marc21RecordServiceConfig,
 )
-
-
-class Metadata:
-    """Marc21 Metadata object."""
-
-    _json = {}
-    _xml = ""
-
-    @property
-    def json(self):
-        """Metadata json getter method."""
-        return self._json
-
-    @json.setter
-    def json(self, json: dict):
-        """Metadata json setter method."""
-        if not isinstance(json, dict):
-            raise TypeError("json must be from type dict")
-        self._json = json
-
-    @property
-    def xml(self):
-        """Metadata xml getter method."""
-        return self._xml
-
-    @xml.setter
-    def xml(self, xml: str):
-        """Metadata xml setter method."""
-        if not isinstance(xml, str):
-            raise TypeError("xml must be from type str")
-        self._xml = xml
+from .record import Marc21Metadata
 
 
 class Marc21RecordService(RecordService):
@@ -82,7 +52,7 @@ class Marc21RecordService(RecordService):
         return data
 
     def create(
-        self, identity, data=None, metadata=Metadata(), access=None
+        self, identity, data=None, metadata=Marc21Metadata(), access=None
     ) -> RecordItem:
         """Create a draft record.
 
@@ -100,7 +70,7 @@ class Marc21RecordService(RecordService):
         id_,
         identity,
         data=None,
-        metadata=Metadata(),
+        metadata=Marc21Metadata(),
         revision_id=None,
         access=None,
     ):

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup_requires = [
 install_requires = [
     "invenio-i18n>=1.3.0",
     "dojson>=1.4.0",
+    "lxml>=4.6.2",
     "invenio-records-rest>=1.5.0,<2.0.0",
     "invenio-drafts-resources>=0.12.0,<0.13.0",
     "invenio-vocabularies>=0.6.0,<0.7.0",

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -22,8 +22,8 @@ from invenio_records_marc21.records import Marc21Draft
 from invenio_records_marc21.services import (
     Marc21RecordService,
     Marc21RecordServiceConfig,
-    Metadata,
 )
+from invenio_records_marc21.services.record import Marc21Metadata
 
 
 @pytest.fixture(scope="module")
@@ -57,19 +57,14 @@ def example_record(app, db):
 @pytest.fixture()
 def metadata():
     """Input data (as coming from the view layer)."""
-    metadata = Metadata()
-    metadata.xml = "<record><datafield tag='245' ind1='1' ind2='0'>\
-            <subfield code='a'>laborum sunt ut nulla</subfield>\
-    </datafield></record>"
+    metadata = Marc21Metadata()
+    metadata.add_value(tag="245", ind1="1", ind2="0", value="laborum sunt ut nulla")
     return metadata
 
 
 @pytest.fixture()
 def metadata2():
     """Input data (as coming from the view layer)."""
-    metadata = Metadata()
-    metadata.xml = "<record>\
-    <datafield tag='245' ind1='1' ind2='0'>\
-        <subfield code='a'>nulla sunt laborum</subfield>\
-    </datafield></record>"
+    metadata = Marc21Metadata()
+    metadata.add_value(tag="245", ind1="1", ind2="0", value="nulla sunt laborum")
     return metadata

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -58,7 +58,7 @@ def example_record(app, db):
 def metadata():
     """Input data (as coming from the view layer)."""
     metadata = Marc21Metadata()
-    metadata.add_value(tag="245", ind1="1", ind2="0", value="laborum sunt ut nulla")
+    metadata.emplace_field(tag="245", ind1="1", ind2="0", value="laborum sunt ut nulla")
     return metadata
 
 
@@ -66,5 +66,5 @@ def metadata():
 def metadata2():
     """Input data (as coming from the view layer)."""
     metadata = Marc21Metadata()
-    metadata.add_value(tag="245", ind1="1", ind2="0", value="nulla sunt laborum")
+    metadata.emplace_field(tag="245", ind1="1", ind2="0", value="nulla sunt laborum")
     return metadata

--- a/tests/services/record/conftest.py
+++ b/tests/services/record/conftest.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Graz University of Technology.
+#
+# Invenio-Records-Marc21 is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+
+"""Pytest configuration.
+
+See https://pytest-invenio.readthedocs.io/ for documentation on which test
+fixtures are available.
+"""
+
+import pytest

--- a/tests/services/record/fields/conftest.py
+++ b/tests/services/record/fields/conftest.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Graz University of Technology.
+#
+# Invenio-Records-Marc21 is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+
+"""Pytest configuration.
+
+See https://pytest-invenio.readthedocs.io/ for documentation on which test
+fixtures are available.
+"""
+
+import pytest
+
+
+@pytest.fixture()
+def leader_kwargs():
+    """Input data (as coming from the view layer)."""
+    leader = {}
+    leader["length"] = "00000"
+    leader["status"] = "n"
+    leader["type"] = "a"
+    leader["level"] = "m"
+    leader["control"] = " "
+    leader["charset"] = "a"
+
+    leader["ind_count"] = "2"
+    leader["sub_count"] = "2"
+    leader["address"] = "00000"
+    leader["encoding"] = "z"
+    leader["description"] = "c"
+    leader["multipart_resource_record_level"] = "a"
+    leader["length_field_position"] = "4"
+    leader["length_starting_character_position_portion"] = "5"
+    leader["length_implementation_defined_portion"] = "0"
+    leader["undefined"] = "0"
+    return leader

--- a/tests/services/record/fields/test_controlfield.py
+++ b/tests/services/record/fields/test_controlfield.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Graz University of Technology.
+#
+# Invenio-Records-Marc21 is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+
+"""Pytest configuration.
+
+See https://pytest-invenio.readthedocs.io/ for documentation on which test
+fixtures are available.
+"""
+
+import pytest
+
+from invenio_records_marc21.services.record import ControlField
+
+
+def test_controlfield():
+    controlfield = ControlField()
+    assert controlfield.tag == ""
+    assert controlfield.value == ""
+
+    controlfield = ControlField("12")
+    assert controlfield.tag == "12"
+    assert controlfield.value == ""
+
+    controlfield = ControlField(tag="123", value="laborum sunt ut nulla")
+    assert controlfield.tag == "123"
+    assert controlfield.value == "laborum sunt ut nulla"
+
+
+def test_controlfield_to_xml():
+    controlfield = ControlField(tag="123", value="laborum sunt ut nulla")
+    xml = controlfield.to_xml_tag()
+    assert '<controlfield tag="123">laborum sunt ut nulla' in xml
+    assert '</controlfield>' in xml
+    assert xml.startswith("    ")
+    assert xml.endswith("\n")
+
+    xml = controlfield.to_xml_tag(tagsep="", indent=0)
+    assert '<controlfield tag="123">laborum sunt ut nulla</controlfield>' == xml

--- a/tests/services/record/fields/test_controlfield.py
+++ b/tests/services/record/fields/test_controlfield.py
@@ -36,7 +36,7 @@ def test_controlfield_to_xml():
     controlfield = ControlField(tag="123", value="laborum sunt ut nulla")
     xml = controlfield.to_xml_tag()
     assert '<controlfield tag="123">laborum sunt ut nulla' in xml
-    assert '</controlfield>' in xml
+    assert "</controlfield>" in xml
     assert xml.startswith("    ")
     assert xml.endswith("\n")
 

--- a/tests/services/record/fields/test_datafield.py
+++ b/tests/services/record/fields/test_datafield.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Graz University of Technology.
+#
+# Invenio-Records-Marc21 is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+
+"""Pytest configuration.
+
+See https://pytest-invenio.readthedocs.io/ for documentation on which test
+fixtures are available.
+"""
+
+import pytest
+
+from invenio_records_marc21.services.record import DataField, SubField
+
+
+def test_datafield():
+    datafield = DataField()
+    assert datafield.tag == ""
+    assert datafield.ind1 == " "
+    assert datafield.ind2 == " "
+    assert datafield.subfields == list()
+
+    datafield = DataField("laborum", "a", "b")
+    assert datafield.tag == "laborum"
+    assert datafield.ind1 == "a"
+    assert datafield.ind2 == "b"
+
+    subfield = SubField(code="123", value="laborum sunt ut nulla")
+    datafield.subfields.append(subfield)
+    assert len(datafield.subfields) == 1
+
+
+def test_datafield_to_xml():
+    subfield = SubField(code="123", value="laborum sunt ut nulla")
+    datafield = DataField("laborum")
+    datafield.subfields.append(subfield)
+
+    xml = datafield.to_xml_tag()
+    assert '<datafield tag="laborum" ind1=" " ind2=" ">\n' in xml
+    assert '<subfield code="123">laborum sunt ut nulla</subfield>' in xml
+    assert xml.startswith("    ")
+    assert xml.endswith("\n")
+
+    xml = datafield.to_xml_tag(tagsep="", indent=0)
+    assert xml.startswith(
+        '<datafield tag="laborum" ind1=" " ind2=" "><subfield code="123">laborum sunt ut nulla</subfield>'
+    )

--- a/tests/services/record/fields/test_leaderfield.py
+++ b/tests/services/record/fields/test_leaderfield.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Graz University of Technology.
+#
+# Invenio-Records-Marc21 is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+
+"""Pytest configuration.
+
+See https://pytest-invenio.readthedocs.io/ for documentation on which test
+fixtures are available.
+"""
+
+import pytest
+
+from invenio_records_marc21.services.record.fields import LeaderField
+
+
+def _assert_field_value(fields, object, expected):
+    for key in fields:
+        assert getattr(object, key) == expected[key]
+
+
+def test_leaderfield(leader_kwargs):
+    leaderfield = LeaderField()
+    _assert_field_value(leader_kwargs.keys(), leaderfield, leader_kwargs)
+
+    leader_kwargs["length"] = "99999"
+    leaderfield = LeaderField(**leader_kwargs)
+    _assert_field_value(leader_kwargs.keys(), leaderfield, leader_kwargs)
+
+    leader_kwargs["status"] = "d"
+    leaderfield = LeaderField(**leader_kwargs)
+    _assert_field_value(leader_kwargs.keys(), leaderfield, leader_kwargs)
+
+    leader_kwargs["type"] = "g"
+    leaderfield = LeaderField(**leader_kwargs)
+    _assert_field_value(leader_kwargs.keys(), leaderfield, leader_kwargs)
+
+    leader_kwargs["level"] = "c"
+    leaderfield = LeaderField(**leader_kwargs)
+    _assert_field_value(leader_kwargs.keys(), leaderfield, leader_kwargs)
+
+    leader_kwargs["control"] = "a"
+    leaderfield = LeaderField(**leader_kwargs)
+    _assert_field_value(leader_kwargs.keys(), leaderfield, leader_kwargs)
+
+    leader_kwargs["charset"] = " "
+    leaderfield = LeaderField(**leader_kwargs)
+    _assert_field_value(leader_kwargs.keys(), leaderfield, leader_kwargs)
+
+    leader_kwargs["ind_count"] = "6"
+    leaderfield = LeaderField(**leader_kwargs)
+    _assert_field_value(leader_kwargs.keys(), leaderfield, leader_kwargs)
+
+    leader_kwargs["sub_count"] = "6"
+    leaderfield = LeaderField(**leader_kwargs)
+    _assert_field_value(leader_kwargs.keys(), leaderfield, leader_kwargs)
+
+    leader_kwargs["ind_count"] = "6"
+    leaderfield = LeaderField(**leader_kwargs)
+    _assert_field_value(leader_kwargs.keys(), leaderfield, leader_kwargs)
+
+    leader_kwargs["address"] = "99999"
+    leaderfield = LeaderField(**leader_kwargs)
+    _assert_field_value(leader_kwargs.keys(), leaderfield, leader_kwargs)
+
+    leader_kwargs["encoding"] = "u"
+    leaderfield = LeaderField(**leader_kwargs)
+    _assert_field_value(leader_kwargs.keys(), leaderfield, leader_kwargs)
+
+    leader_kwargs["description"] = "a"
+    leaderfield = LeaderField(**leader_kwargs)
+    _assert_field_value(leader_kwargs.keys(), leaderfield, leader_kwargs)
+
+    leader_kwargs["multipart_resource_record_level"] = " "
+    leaderfield = LeaderField(**leader_kwargs)
+    _assert_field_value(leader_kwargs.keys(), leaderfield, leader_kwargs)
+
+    leader_kwargs["length_field_position"] = "9"
+    leaderfield = LeaderField(**leader_kwargs)
+    _assert_field_value(leader_kwargs.keys(), leaderfield, leader_kwargs)
+
+    leader_kwargs["length_starting_character_position_portion"] = "9"
+    leaderfield = LeaderField(**leader_kwargs)
+    _assert_field_value(leader_kwargs.keys(), leaderfield, leader_kwargs)
+
+    leader_kwargs["length_implementation_defined_portion"] = "9"
+    leaderfield = LeaderField(**leader_kwargs)
+    _assert_field_value(leader_kwargs.keys(), leaderfield, leader_kwargs)
+
+    leader_kwargs["undefined"] = "9"
+    leaderfield = LeaderField(**leader_kwargs)
+    _assert_field_value(leader_kwargs.keys(), leaderfield, leader_kwargs)
+
+
+def test_leaderfield_to_xml(leader_kwargs):
+    leaderfield = LeaderField(**leader_kwargs)
+    xml = leaderfield.to_xml_tag()
+    assert "<leader>00000nam a2200000zca4500</leader>" in xml
+    assert xml.startswith("    ")
+    assert xml.endswith("\n")
+
+    xml = leaderfield.to_xml_tag(tagsep="", indent=0)
+    assert "<leader>00000nam a2200000zca4500</leader>" == xml

--- a/tests/services/record/fields/test_subfield.py
+++ b/tests/services/record/fields/test_subfield.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Graz University of Technology.
+#
+# Invenio-Records-Marc21 is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+
+"""Pytest configuration.
+
+See https://pytest-invenio.readthedocs.io/ for documentation on which test
+fixtures are available.
+"""
+
+import pytest
+
+from invenio_records_marc21.services.record import SubField
+
+
+def test_subfield():
+    subfield = SubField()
+    assert subfield.code == ""
+    assert subfield.value == ""
+
+    subfield = SubField("12")
+    assert subfield.code == "12"
+    assert subfield.value == ""
+
+    subfield = SubField(code="123", value="laborum sunt ut nulla")
+    assert subfield.code == "123"
+    assert subfield.value == "laborum sunt ut nulla"
+
+
+def test_subfield_to_xml():
+    subfield = SubField(code="123", value="laborum sunt ut nulla")
+    xml = subfield.to_xml_tag()
+    assert '<subfield code="123">laborum sunt ut nulla</subfield>' in xml
+    assert xml.startswith("        ")
+    assert xml.endswith("\n")
+
+    xml = subfield.to_xml_tag(tagsep="", indent=0)
+    assert '<subfield code="123">laborum sunt ut nulla</subfield>' == xml

--- a/tests/services/record/test_marc21_metadata.py
+++ b/tests/services/record/test_marc21_metadata.py
@@ -44,7 +44,7 @@ def test_create_metadata():
     )
     assert 'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"' in metadata.xml
 
-    metadata.add_value(
+    metadata.emplace_field(
         tag="245", ind1="1", ind2="0", code="a", value="laborum sunt ut nulla"
     )
 
@@ -54,12 +54,12 @@ def test_create_metadata():
 
 def test_validate_metadata():
     metadata = Marc21Metadata()
-    metadata.add_value(
+    metadata.emplace_field(
         tag="245", ind1="1", ind2="0", code="a", value="laborum sunt ut nulla"
     )
     assert metadata.is_valid_marc21_xml_string()
 
-    metadata.add_value(
+    metadata.emplace_field(
         tag="245", ind1="1", ind2="0", code="", value="laborum sunt ut nulla"
     )
 
@@ -68,11 +68,11 @@ def test_validate_metadata():
 
 def test_subfield_metadata():
     metadata = Marc21Metadata()
-    metadata.add_value(
+    metadata.emplace_field(
         tag="245", ind1="1", ind2="0", code="a", value="laborum sunt ut nulla"
     )
 
-    metadata.add_value(
+    metadata.emplace_field(
         tag="245", ind1="1", ind2="0", code="b", value="laborum sunt ut nulla"
     )
 
@@ -94,11 +94,11 @@ def test_controlfields_metadata():
 
 def test_uniqueness_metadata():
     metadata = Marc21Metadata()
-    metadata.add_unique_value(
+    metadata.emplace_unique_field(
         tag="245", ind1="1", ind2="0", code="a", value="laborum sunt ut nulla"
     )
 
-    metadata.add_unique_value(
+    metadata.emplace_unique_field(
         tag="245", ind1="1", ind2="0", code="a", value="laborum sunt ut nulla"
     )
 

--- a/tests/services/record/test_marc21_metadata.py
+++ b/tests/services/record/test_marc21_metadata.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Graz University of Technology.
+#
+# Invenio-Records-Marc21 is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+
+"""Pytest configuration.
+
+See https://pytest-invenio.readthedocs.io/ for documentation on which test
+fixtures are available.
+"""
+
+from io import StringIO
+from os import linesep
+from os.path import dirname, join
+
+import pytest
+from lxml import etree
+
+from invenio_records_marc21.services.record import Marc21Metadata
+from invenio_records_marc21.services.record.fields import (
+    ControlField,
+    DataField,
+    LeaderField,
+    SubField,
+)
+
+
+def test_create_metadata():
+
+    metadata = Marc21Metadata()
+    assert metadata.leader.to_xml_tag() == LeaderField().to_xml_tag()
+    assert metadata.controlfields == list()
+    assert metadata.datafields == list()
+
+    assert "<?xml version='1.0' ?>" in metadata.xml
+    assert '<record xmlns="http://www.loc.gov/MARC21/slim"' in metadata.xml
+    assert (
+        'xsi:schemaLocation="http://www.loc.gov/MARC21/slim schema.xsd" type="Bibliographic"'
+        in metadata.xml
+    )
+    assert 'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"' in metadata.xml
+
+    metadata.add_value(
+        tag="245", ind1="1", ind2="0", code="a", value="laborum sunt ut nulla"
+    )
+
+    assert '<datafield tag="245" ind1="1" ind2="0">' in metadata.xml
+    assert '<subfield code="a">laborum sunt ut nulla</subfield>' in metadata.xml
+
+
+def test_validate_metadata():
+    metadata = Marc21Metadata()
+    metadata.add_value(
+        tag="245", ind1="1", ind2="0", code="a", value="laborum sunt ut nulla"
+    )
+    assert metadata.is_valid_marc21_xml_string()
+
+    metadata.add_value(
+        tag="245", ind1="1", ind2="0", code="", value="laborum sunt ut nulla"
+    )
+
+    assert not metadata.is_valid_marc21_xml_string()
+
+
+def test_subfield_metadata():
+    metadata = Marc21Metadata()
+    metadata.add_value(
+        tag="245", ind1="1", ind2="0", code="a", value="laborum sunt ut nulla"
+    )
+
+    metadata.add_value(
+        tag="245", ind1="1", ind2="0", code="b", value="laborum sunt ut nulla"
+    )
+
+    assert metadata.is_valid_marc21_xml_string()
+
+
+def test_controlfields_metadata():
+    metadata = Marc21Metadata()
+    controlfield = ControlField(tag="123", value="laborum sunt ut nulla")
+
+    assert len(metadata.datafields) == 0
+    assert len(metadata.controlfields) == 0
+
+    metadata.controlfields.append(controlfield)
+    assert len(metadata.datafields) == 0
+    assert len(metadata.controlfields) == 1
+    assert '<controlfield tag="123">laborum sunt ut nulla' in metadata.xml
+
+
+def test_uniqueness_metadata():
+    metadata = Marc21Metadata()
+    metadata.add_unique_value(
+        tag="245", ind1="1", ind2="0", code="a", value="laborum sunt ut nulla"
+    )
+
+    metadata.add_unique_value(
+        tag="245", ind1="1", ind2="0", code="a", value="laborum sunt ut nulla"
+    )
+
+    assert len(metadata.datafields) == 1
+    assert len(metadata.controlfields) == 0
+    assert len(metadata.datafields[0].subfields) == 1
+    assert metadata.is_valid_marc21_xml_string()
+
+
+def test_xml_type():
+    metadata = Marc21Metadata()
+
+    test = '<datafield tag="245" ind1="0" ind2="0"></datafield>'
+    metadata.xml = test
+    assert metadata.xml
+
+    test = {}
+    with pytest.raises(TypeError):
+        metadata.xml = test
+
+
+def test_json_type():
+    metadata = Marc21Metadata()
+
+    test = dict()
+    metadata.json = test
+    assert metadata.json == {}
+
+    test = ""
+    with pytest.raises(TypeError):
+        metadata.json = test
+
+
+def test_xml_metadata():
+    metadata = Marc21Metadata()
+    test = DataField(tag="245", ind1="0", ind2="0")
+
+    metadata.xml = test.to_xml_tag()
+
+    assert metadata.leader.to_xml_tag() == LeaderField().to_xml_tag()
+    assert len(metadata.datafields) == 1
+    assert len(metadata.controlfields) == 0
+    assert len(metadata.datafields[0].subfields) == 0
+    assert test.to_xml_tag() in metadata.xml
+
+    test.subfields.append(SubField(code="a", value="Brain-Computer Interface"))
+    metadata = Marc21Metadata()
+    metadata.xml = test.to_xml_tag()
+
+    assert len(metadata.datafields) == 1
+    assert len(metadata.controlfields) == 0
+    assert len(metadata.datafields[0].subfields) == 1
+    assert test.to_xml_tag() in metadata.xml
+
+    test.subfields.append(SubField(code="b", value="Subtitle field."))
+    metadata = Marc21Metadata()
+    metadata.xml = test.to_xml_tag()
+
+    assert len(metadata.datafields) == 1
+    assert len(metadata.controlfields) == 0
+    assert len(metadata.datafields[0].subfields) == 2
+    assert test.to_xml_tag() in metadata.xml
+
+    test.subfields.append(SubField(code="c", value="hrsg. von Josef Frank"))
+    metadata = Marc21Metadata()
+    metadata.xml = test.to_xml_tag()
+
+    assert len(metadata.datafields) == 1
+    assert len(metadata.controlfields) == 0
+    assert len(metadata.datafields[0].subfields) == 3
+    assert test.to_xml_tag() in metadata.xml


### PR DESCRIPTION
adding Marc21Metadata object allowing other modules to build a marc21 XML and store it in the repository.
Also, add a test set for metadata and for the fields in the metadata structure.