### PR TITLE
CI: build errors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,8 +68,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Generate dependencies
+        # setuptools lower verion needed due to build errors in dependencies: Issue #2769
         run: |
-          python -m pip install --upgrade pip setuptools py wheel requirements-builder
+          python -m pip install --upgrade pip py wheel requirements-builder
+          python -m pip install --upgrade setuptools==57.5.0
           requirements-builder -e "$EXTRAS" --level=${{ matrix.requirements-level }} setup.py > .${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt
 
       - name: Cache pip


### PR DESCRIPTION
Build CI with setuptools version 57.5.0 due to the issue #2769 raised from dependency module fs