### PR TITLE
Marc21 File service update

### DIFF
--- a/invenio_records_marc21/services/config.py
+++ b/invenio_records_marc21/services/config.py
@@ -22,6 +22,7 @@ from invenio_records_resources.services import (
     pagination_links,
 )
 from invenio_records_resources.services.files.config import FileServiceConfig
+from invenio_records_resources.services.files.links import FileLink
 from invenio_records_resources.services.records.facets import TermsFacet
 from invenio_records_resources.services.records.links import RecordLink
 
@@ -117,14 +118,39 @@ class Marc21RecordServiceConfig(RecordServiceConfig):
 #
 # Record files
 #
-class Marc21RecordFilesServiceConfig(Marc21RecordServiceConfig, FileServiceConfig):
+class Marc21RecordFilesServiceConfig(FileServiceConfig):
     """Marc21 record files service configuration."""
+
+    record_cls = Marc21Record
+    permission_policy_cls = Marc21RecordPermissionPolicy
+    permission_action_prefix = ""
+
+    file_links_list = {
+        "self": RecordLink("{+api}/marc21/{id}/files"),
+    }
+
+    file_links_item = {
+        "self": FileLink("{+api}/marc21/{id}/files/{key}"),
+        "content": FileLink("{+api}/marc21/{id}/files/{key}/content"),
+    }
 
 
 #
 # Draft files
 #
-class Marc21DraftFilesServiceConfig(Marc21RecordServiceConfig, FileServiceConfig):
+class Marc21DraftFilesServiceConfig(FileServiceConfig):
     """Marc21 draft files service configuration."""
 
     record_cls = Marc21Draft
+    permission_policy_cls = Marc21RecordPermissionPolicy
+    permission_action_prefix = "draft_"
+
+    file_links_list = {
+        "self": RecordLink("{+api}/marc21/draft/{id}/files"),
+    }
+
+    file_links_item = {
+        "self": FileLink("{+api}/marc21/{id}/draft/files/{key}"),
+        "content": FileLink("{+api}/marc21/{id}/draft/files/{key}/content"),
+        "commit": FileLink("{+api}/marc21/{id}/draft/files/{key}/commit"),
+    }

--- a/invenio_records_marc21/templates/invenio_records_marc21/records/export.html
+++ b/invenio_records_marc21/templates/invenio_records_marc21/records/export.html
@@ -24,7 +24,7 @@
             </div>
             <div class="right floated right aligned column">
               <div class="two wide column">
-                <a class="ui button small compact" href="{{ url_for('invenio_records_marc21.record_detail', pid_value=record.id) }}"><i class="ui icon angle left"></i> {{_('Back to details') }}</a>
+                <a class="ui button small compact" href="{{ url_for('invenio_records_marc21.record_detail', pid_value=pid_value) }}"><i class="ui icon angle left"></i> {{_('Back to details') }}</a>
               </div>
             </div>
           </div>

--- a/invenio_records_marc21/ui/records/records.py
+++ b/invenio_records_marc21/ui/records/records.py
@@ -54,6 +54,7 @@ def record_export(record=None, export_format=None, pid_value=None, permissions=N
 
     return render_template(
         "invenio_records_marc21/records/export.html",
+        pid_value=pid_value,
         export_format=exporter.get("name", export_format),
         exported_record=exported_record,
         record=Marc21UIJSONSerializer().dump_one(record.to_dict()),

--- a/invenio_records_marc21/ui/records/records.py
+++ b/invenio_records_marc21/ui/records/records.py
@@ -12,13 +12,14 @@ from flask import abort, current_app, render_template
 from invenio_base.utils import obj_or_import_string
 
 from ...resources.serializers.ui import Marc21UIJSONSerializer
-from .decorators import pass_record_or_draft, user_permissions
+from .decorators import pass_record_files, pass_record_or_draft, user_permissions
 
 
 #
 # Views
 #
 @pass_record_or_draft
+@pass_record_files
 def record_detail(record=None, files=None, pid_value=None, permissions=None):
     """Record detail page (aka landing page)."""
     files_dict = None if files is None else files.to_dict()

--- a/invenio_records_marc21/ui/records/records.py
+++ b/invenio_records_marc21/ui/records/records.py
@@ -12,14 +12,13 @@ from flask import abort, current_app, render_template
 from invenio_base.utils import obj_or_import_string
 
 from ...resources.serializers.ui import Marc21UIJSONSerializer
-from .decorators import pass_record, user_permissions
+from .decorators import pass_record_or_draft, user_permissions
 
 
 #
 # Views
 #
-@pass_record
-@user_permissions(actions=["update_draft"])
+@pass_record_or_draft
 def record_detail(record=None, files=None, pid_value=None, permissions=None):
     """Record detail page (aka landing page)."""
     files_dict = None if files is None else files.to_dict()
@@ -32,7 +31,7 @@ def record_detail(record=None, files=None, pid_value=None, permissions=None):
     )
 
 
-@pass_record
+@pass_record_or_draft
 def record_export(record=None, export_format=None, pid_value=None, permissions=None):
     """Export marc21 record page view."""
     exporter = current_app.config.get("INVENIO_MARC21_RECORD_EXPORTERS", {}).get(


### PR DESCRIPTION
Update the marc21 record file service and print corrected links to files  e.g. 
`https://127.0.0.1:5000/api/marc21/zkqdc-09b59/files` instead of `https://127.0.0.1:5000/api/records/zkqdc-09b59/files`
and passing files to the record landing page.