### PR TITLE
add functionality to set a pre-calculated marcid

### DIFF
--- a/invenio_records_marc21/records/systemfields/providers.py
+++ b/invenio_records_marc21/records/systemfields/providers.py
@@ -32,3 +32,28 @@ class MarcDraftProvider(MarcRecordProvider):
     """
 
     default_status_with_obj = PIDStatus.NEW
+
+    predefined_pid_value = ""
+
+    @classmethod
+    def create(cls, object_type=None, object_uuid=None, options=None, **kwargs):
+        """Intermediate step to create the marcid.
+
+        With this intermediate step it is possible to set pre-calculated marcid's.
+        """
+        if (
+            "record" in kwargs and "$schema" in kwargs["record"]
+        ) or cls.predefined_pid_value == "":
+            return super(MarcDraftProvider, cls).create(
+                object_type=object_type, object_uuid=object_uuid, **kwargs
+            )
+        else:
+            kwargs["pid_value"] = cls.predefined_pid_value
+            kwargs.setdefault("status", cls.default_status)
+
+            if object_type and object_uuid:
+                kwargs["status"] = cls.default_status_with_obj
+
+            return super(RecordIdProviderV2, cls).create(
+                object_type=object_type, object_uuid=object_uuid, **kwargs
+            )


### PR DESCRIPTION
With that hack it is possible to create a record with a pre-calculated marcid.
This approach is necessary because there exists for now some DOI's with marcid (with no
corresponding record in the repository) where the records should
have then also the same marcid when they will be created then in the repository.

To set the pre-calculated marcid it has to be assigned to
MarcDraftProvider.predefined_pid_value before the creation of the record with
the corresponding service