### PR TITLE
Bugfix: marc21metadata load etree

### DIFF
--- a/invenio_records_marc21/services/record/metadata.py
+++ b/invenio_records_marc21/services/record/metadata.py
@@ -72,7 +72,6 @@ class Marc21Metadata(object):
     def load(self, xml: etree):
         """Load metadata from etree."""
         self._etree = xml
-        self._to_xml_tree(xml)
 
     def _to_xml_tree_from_string(self, xml: str):
         """Xml string to internal representation method."""

--- a/invenio_records_marc21/services/record/metadata.py
+++ b/invenio_records_marc21/services/record/metadata.py
@@ -65,8 +65,7 @@ class Marc21Metadata(object):
         if not isinstance(xml, str):
             raise TypeError("xml must be from type str")
 
-        tree = self._to_xml_tree_from_string(xml)
-        self._etree = tree
+        self._etree = self._to_xml_tree_from_string(xml)
         self._xml = xml
 
     def load(self, xml: etree):

--- a/tests/services/record/test_marc21_metadata.py
+++ b/tests/services/record/test_marc21_metadata.py
@@ -155,6 +155,50 @@ def test_contains_metadata():
     )
 
 
+def test_load_metadata():
+    metadata = Marc21Metadata()
+
+    etree_metadata = etree.Element("record")
+    control = etree.Element("controlfield", tag="001")
+    control.text = "990079940640203331"
+    etree_metadata.append(control)
+
+    datafield = etree.Element("datafield", tag="245", ind1="0", ind2="0")
+    title = etree.Element("subfield", code="a")
+    title.text = "International Brain-Computer Interface"
+    datafield.append(title)
+
+    subtitle = etree.Element("subfield", code="b")
+    subtitle.text = "Subtitle field"
+    datafield.append(subtitle)
+
+    etree_metadata.append(datafield)
+
+    metadata.load(etree_metadata)
+    assert metadata._etree == etree_metadata
+
+    controlfield = metadata._etree.xpath(".//controlfield[@tag='001']")
+    assert controlfield
+    assert len(controlfield) == 1
+    assert controlfield[0].text == "990079940640203331"
+
+    datafield = metadata._etree.xpath(".//datafield[@tag='245' and @ind2='0' and @ind1='0']")
+    assert datafield
+    assert len(datafield) == 1
+
+    title_field = datafield[0].xpath(".//subfield[@code='a']")
+
+    assert title_field
+    assert len(title_field) == 1
+    assert title_field[0].text == "International Brain-Computer Interface"
+
+    subfields = datafield[0].xpath(".//subfield[@code='b']")
+
+    assert subfields
+    assert len(subfields) == 1
+    subfields[0].text = "Subtitle field"
+
+
 def test_xml_type():
     metadata = Marc21Metadata()
 


### PR DESCRIPTION
remove deprecated function and adding testset to load marc21metadata lxml trees