### PR TITLE
fix: the missing mappings causes an error with the empty search feature

### DIFF
--- a/invenio_records_marc21/records/mappings/v7/marc21records/drafts/marc21-v1.0.0.json
+++ b/invenio_records_marc21/records/mappings/v7/marc21records/drafts/marc21-v1.0.0.json
@@ -1,6 +1,140 @@
 {
   "mappings": {
     "date_detection": false,
-    "numeric_detection": false
+    "numeric_detection": false,
+    "dynamic_templates": [
+      {
+        "#text": {
+          "match": "#text",
+          "mapping": {
+            "type": "text"
+          }
+        }
+      }
+    ],
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "access": {
+        "properties": {
+          "record": {
+            "type": "keyword"
+          },
+          "files": {
+            "type": "keyword"
+          },
+          "embargo": {
+            "properties": {
+              "active": {
+                "type": "boolean"
+              },
+              "until": {
+                "type": "date"
+              },
+              "reason": {
+                "type": "text"
+              }
+            }
+          },
+          "status": {
+            "type": "keyword"
+          }
+        }
+      },
+      "parent": {
+        "properties": {
+          "id": {
+            "type": "keyword"
+          },
+          "access": {
+            "properties": {
+              "owned_by": {
+                "properties": {
+                  "user": {
+                    "type": "keyword"
+                  }
+                }
+              },
+              "grants": {
+                "properties": {
+                  "subject": {
+                    "type": "keyword"
+                  },
+                  "id": {
+                    "type": "keyword"
+                  },
+                  "level": {
+                    "type": "keyword"
+                  }
+                }
+              },
+              "grant_tokens": {
+                "type": "keyword"
+              },
+              "links": {
+                "properties": {
+                  "id": {
+                    "type": "keyword"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "pids": {
+        "properties": {
+          "identifier": {
+            "type": "keyword"
+          },
+          "scheme": {
+            "type": "keyword"
+          },
+          "client": {
+            "type": "keyword",
+            "index": false
+          },
+          "provider": {
+            "type": "keyword",
+            "index": false
+          }
+        }
+      },
+      "has_draft": {
+        "type": "boolean"
+      },
+      "created": {
+        "type": "date"
+      },
+      "updated": {
+        "type": "date"
+      },
+      "is_published": {
+        "type": "boolean"
+      },
+      "versions": {
+        "properties": {
+          "index": {
+            "type": "integer"
+          },
+          "is_latest": {
+            "type": "boolean"
+          },
+          "is_latest_draft": {
+            "type": "boolean"
+          },
+          "latest_id": {
+            "type": "keyword"
+          },
+          "latest_index": {
+            "type": "integer"
+          },
+          "next_draft_id": {
+            "type": "keyword"
+          }
+        }
+      }
+    }
   }
 }

--- a/invenio_records_marc21/records/mappings/v7/marc21records/marc21/marc21-v1.0.0.json
+++ b/invenio_records_marc21/records/mappings/v7/marc21records/marc21/marc21-v1.0.0.json
@@ -1,6 +1,140 @@
 {
   "mappings": {
     "date_detection": false,
-    "numeric_detection": false
+    "numeric_detection": false,
+    "dynamic_templates": [
+      {
+        "#text": {
+          "match": "#text",
+          "mapping": {
+            "type": "text"
+          }
+        }
+      }
+    ],
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "access": {
+        "properties": {
+          "record": {
+            "type": "keyword"
+          },
+          "files": {
+            "type": "keyword"
+          },
+          "embargo": {
+            "properties": {
+              "active": {
+                "type": "boolean"
+              },
+              "until": {
+                "type": "date"
+              },
+              "reason": {
+                "type": "text"
+              }
+            }
+          },
+          "status": {
+            "type": "keyword"
+          }
+        }
+      },
+      "parent": {
+        "properties": {
+          "id": {
+            "type": "keyword"
+          },
+          "access": {
+            "properties": {
+              "owned_by": {
+                "properties": {
+                  "user": {
+                    "type": "keyword"
+                  }
+                }
+              },
+              "grants": {
+                "properties": {
+                  "subject": {
+                    "type": "keyword"
+                  },
+                  "id": {
+                    "type": "keyword"
+                  },
+                  "level": {
+                    "type": "keyword"
+                  }
+                }
+              },
+              "grant_tokens": {
+                "type": "keyword"
+              },
+              "links": {
+                "properties": {
+                  "id": {
+                    "type": "keyword"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "pids": {
+        "properties": {
+          "identifier": {
+            "type": "keyword"
+          },
+          "scheme": {
+            "type": "keyword"
+          },
+          "client": {
+            "type": "keyword",
+            "index": false
+          },
+          "provider": {
+            "type": "keyword",
+            "index": false
+          }
+        }
+      },
+      "has_draft": {
+        "type": "boolean"
+      },
+      "created": {
+        "type": "date"
+      },
+      "updated": {
+        "type": "date"
+      },
+      "is_published": {
+        "type": "boolean"
+      },
+      "versions": {
+        "properties": {
+          "index": {
+            "type": "integer"
+          },
+          "is_latest": {
+            "type": "boolean"
+          },
+          "is_latest_draft": {
+            "type": "boolean"
+          },
+          "latest_id": {
+            "type": "keyword"
+          },
+          "latest_index": {
+            "type": "integer"
+          },
+          "next_draft_id": {
+            "type": "keyword"
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
The change is necessary to get rid of following error message:

Text fields are not optimised for operations that require per-document field
data like aggregations and sorting, so these operations are disabled by default.
Please use a keyword field instead. Alternatively, set fielddata=true on
[created] in order to load field data by uninverting the inverted index. Note
that this can use significant memory.

This fix is a quick fix. it should be refactored to be a real mapping.
