### PR TITLE
fix: pypi-publish inherit secrets

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -6,3 +6,4 @@ on:
 jobs:
   build-n-publish:
     uses: tu-graz-library/.github/.github/workflows/pypi-publish.yml@main
+    secrets: inherit


### PR DESCRIPTION
* it seams that also organizational secrets have to be given explicitly
  to the called workflow
