### PR TITLE
fix: wrong alias for drafts and records

### DIFF
--- a/invenio_records_marc21/services/record/utils.py
+++ b/invenio_records_marc21/services/record/utils.py
@@ -63,7 +63,7 @@ def create_record(service, data, file_paths, identity, do_publish=True):
 @singledispatch
 def check_about_duplicate(value: str, category: str = None):
     """Check if the record with the ac number is already within the database."""
-    search = RecordsSearch(index="marc21records-marc21")
+    search = RecordsSearch(index="marc21records")
 
     if category:
         query = {f"metadata.fields.{category}": value}


### PR DESCRIPTION
* the used alias was only for published records, but the check should
  also against drafts, otherwise it could happen that multiple drafts of
  one import could exists which would then be handled by further
  updates, which would lead to published duplicates because at that
  stage no checks would be called.
