### PR TITLE
fix: unify order of et.Element attributes

### DIFF
--- a/invenio_records_marc21/resources/serializers/serializer.py
+++ b/invenio_records_marc21/resources/serializers/serializer.py
@@ -82,7 +82,6 @@ class Marc21XMLMixin:
                 controlfield.attrib["tag"] = key
                 rec.append(controlfield)
             else:
-
                 for subfields in value:
                     datafield = E.datafield()
                     datafield.attrib["tag"] = key

--- a/invenio_records_marc21/services/record/metadata.py
+++ b/invenio_records_marc21/services/record/metadata.py
@@ -71,7 +71,7 @@ class JsonToXmlVisitor:
         for item in items:
             datafield = Element(
                 "datafield",
-                {"ind1": item["ind1"], "ind2": item["ind2"], "tag": category},
+                {"tag": category, "ind1": item["ind1"], "ind2": item["ind2"]},
             )
             for subfn, subfv in item["subfields"].items():
                 subfield = Element("subfield", {"code": subfn})

--- a/invenio_records_marc21/services/record/metadata.py
+++ b/invenio_records_marc21/services/record/metadata.py
@@ -73,7 +73,7 @@ class JsonToXmlVisitor:
                 "datafield",
                 {"tag": category, "ind1": item["ind1"], "ind2": item["ind2"]},
             )
-            for subfn, subfv in item["subfields"].items():
+            for subfn, subfv in sorted(item["subfields"].items()):
                 subfield = Element("subfield", {"code": subfn})
                 subfield.text = " ".join(subfv)
                 datafield.append(subfield)
@@ -278,7 +278,7 @@ class Marc21Metadata:
             datafield.append(subfield)
 
         elif subfs:
-            for key, val in subfs.items():
+            for key, val in sorted(subfs.items()):
                 subfield = Element("subfield", code=key)
                 subfield.text = " ".join(val)
                 datafield.append(subfield)

--- a/invenio_records_marc21/services/record/metadata.py
+++ b/invenio_records_marc21/services/record/metadata.py
@@ -280,7 +280,7 @@ class Marc21Metadata:
         elif subfs:
             for key, val in subfs.items():
                 subfield = Element("subfield", code=key)
-                subfield.text = val
+                subfield.text = " ".join(val)
                 datafield.append(subfield)
 
         else:


### PR DESCRIPTION
* the problem was, that the Marc21Metadata.emplace_datafield and
  JsonToXmlVistor.visit_datafield methods didn't construct the Element in
  the same way. One moved the tag attribute in the beginning the other in
  the end of the datafield element. This leads to problems of checking the
  equality in Marc21Metadata.exists method.
