### PR TITLE
fix: distinguish between str and list

### DIFF
--- a/invenio_records_marc21/services/record/metadata.py
+++ b/invenio_records_marc21/services/record/metadata.py
@@ -282,7 +282,7 @@ class Marc21Metadata:
         elif subfs:
             for key, val in sorted(subfs.items()):
                 subfield = Element("subfield", code=key)
-                subfield.text = " ".join(val)
+                subfield.text = " ".join(val) if isinstance(val, list) else val
                 datafield.append(subfield)
 
         else:


### PR DESCRIPTION
* the problem was, that normally the subfield value is a list. the
  reason behind this is, it is not guaranteed that a subfield
  code is unique. But it also looks strange to use a list, if there is
  only one element there (and it was used like that in
  invenio-workflows-tugraz) therefore it is now possible to use a list
  or a str
