### PR TITLE
fix: dashboard-visibility not working

### DIFF
--- a/invenio_records_marc21/ui/theme/__init__.py
+++ b/invenio_records_marc21/ui/theme/__init__.py
@@ -10,16 +10,23 @@
 
 """Marc21 Theme Package."""
 
-from flask_login import current_user
+from flask import g
 from flask_menu import current_menu
 from invenio_i18n import lazy_gettext as _
 
+from ...proxies import current_records_marc21
 from .views import deposit_create, deposit_edit, index, search, uploads_marc21
 
 
 #
 # Registration
 #
+def current_identity_can_view() -> bool:
+    """Checks whether current identity has viewing rights."""
+    service = current_records_marc21.records_service
+    return service.check_permission(g.identity, "view")
+
+
 def init_theme_views(blueprint, app):
     """Blueprint for the routes and resources provided by Invenio-Records-Marc21."""
     routes = app.config.get("MARC21_UI_THEME_ENDPOINTS")
@@ -40,7 +47,7 @@ def init_theme_views(blueprint, app):
             "invenio_records_marc21.uploads_marc21",
             text=_("Publications"),
             order=4,
-            visible_when=current_user.is_authenticated,
+            visible_when=current_identity_can_view,
         )
 
     return blueprint


### PR DESCRIPTION
`flask-menu`'s `MenuNode`s' visibility is configurable by passing `visible_when` on initialization.
`visible_when` has to be a `callable[[], bool]` for this to work, but was wrongly set to `True` up to now.

Also, up to now, visibility was to depend on authenticated-ness of the current user,
whereas it should depend on rights to view marc21 records.

These two issues are fixed with this PR.

NOTE: the corresponding html-template will also need to be updated for dashboard-visbility to work...