### PR TITLE
fix: frontent serializer following whitespace

### DIFF
--- a/invenio_records_marc21/ui/theme/assets/semantic-ui/js/invenio_records_marc21/fields/Marc21MetadataFields.js
+++ b/invenio_records_marc21/ui/theme/assets/semantic-ui/js/invenio_records_marc21/fields/Marc21MetadataFields.js
@@ -1,6 +1,6 @@
 // This file is part of Invenio.
 //
-// Copyright (C) 2021-2022 Graz University of Technology.
+// Copyright (C) 2021-2024 Graz University of Technology.
 //
 // React-Records-Marc21 is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see LICENSE file for more
@@ -127,7 +127,7 @@ export class Marc21MetadataFields extends Field {
 
     for (let i = 0; i < subfield_list.length; i++) {
       const subfield = subfield_list[i].split(" ");
-      fields = fields.concat([subfield[0], subfield.slice(1).join(" ")]);
+      fields = fields.concat([subfield[0], subfield.slice(1).join(" ").trim()]);
     }
     return fields;
   }


### PR DESCRIPTION
* the problem was that the serializer which creates the marcxml format
  didn't removed the whitespace at the end of the subfield value. this
  whitespace is there because of splitting by $$
