### PR TITLE
translations: update wording

### DIFF
--- a/invenio_records_marc21/templates/invenio_records_marc21/user_dashboard/uploads.html
+++ b/invenio_records_marc21/templates/invenio_records_marc21/user_dashboard/uploads.html
@@ -4,7 +4,7 @@ Copyright (C) 2023 Graz University of Technology
 invenio-records-marc21 is free software; you can redistribute it and/or modify
 it under the terms of the MIT License; see LICENSE file for more details.
 #}
-{%- set title = _("Uploads") %}
+{%- set title = _("Publication Uploads") %}
 {%- extends config.MARC21_BASE_TEMPLATE %}
 
 {% set active_dashboard_menu_item = 'Marc21' %}

--- a/invenio_records_marc21/translations/de/LC_MESSAGES/messages.po
+++ b/invenio_records_marc21/translations/de/LC_MESSAGES/messages.po
@@ -8,48 +8,67 @@ msgid ""
 msgstr ""
 "Project-Id-Version: invenio-records-marc21 0.2.1\n"
 "Report-Msgid-Bugs-To: info@tugraz.at\n"
-"POT-Creation-Date: 2023-10-03 14:25+0200\n"
-"PO-Revision-Date: 2023-09-14 09:03+0200\n"
+"POT-Creation-Date: 2024-05-19 10:39+0200\n"
+"PO-Revision-Date: 2024-05-19 10:40+0200\n"
 "Last-Translator: \n"
-"Language: de\n"
 "Language-Team: de <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.12.1\n"
+"X-Generator: Poedit 2.3.1\n"
 
-#: invenio_records_marc21/config.py:49
+#: invenio_records_marc21/config.py:179 invenio_records_marc21/config.py:186
+#: invenio_records_marc21/config.py:201 invenio_records_marc21/config.py:209
+#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/macros/doi.html:24
+#: tests/conftest.py:441 tests/conftest.py:448
+msgid "DOI"
+msgstr "DOI"
+
+#: tests/services/schemas/access/test_record.py:45
+msgid "'record' must be either 'public' or 'restricted'"
+msgstr "'Eintrag' muss entweder 'Öffentlich' oder 'Eingeschränkt' sein."
+
+#: tests/services/schemas/access/test_record.py:57
+msgid "'files' must be either 'public' or 'restricted'"
+msgstr "'Datei' muss entweder 'Öffentlich' oder 'Eingeschränkt' sein."
+
+#: invenio_records_marc21/config.py:54
 msgid "Best match"
 msgstr "Höchste Übereinstimmung"
 
-#: invenio_records_marc21/config.py:53
+#: invenio_records_marc21/config.py:58
 msgid "Newest"
 msgstr "Neuester"
 
-#: invenio_records_marc21/config.py:57
+#: invenio_records_marc21/config.py:62
 msgid "Oldest"
 msgstr "Ältester"
 
-#: invenio_records_marc21/config.py:61
+#: invenio_records_marc21/config.py:66
 #, fuzzy
 msgid "Version"
 msgstr "Version"
 
-#: invenio_records_marc21/config.py:65
+#: invenio_records_marc21/config.py:70
 msgid "Recently updated"
 msgstr "Kürzlich aktualisier"
 
-#: invenio_records_marc21/config.py:69
+#: invenio_records_marc21/config.py:74
 msgid "Least recently updated"
 msgstr "Am wenigsten aktuell"
 
-#: invenio_records_marc21/config.py:170 invenio_records_marc21/config.py:177
-#: invenio_records_marc21/config.py:192 invenio_records_marc21/config.py:200
-#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/macros/doi.html:24
-#: tests/conftest.py:438 tests/conftest.py:445
-msgid "DOI"
-msgstr "DOI"
+#: invenio_records_marc21/config.py:78
+msgid "Most viewed"
+msgstr ""
+
+#: invenio_records_marc21/config.py:81
+#, fuzzy
+#| msgid "Download"
+msgid "Most downloaded"
+msgstr "Herunterladen"
 
 #: invenio_records_marc21/errors.py:46
 msgid ""
@@ -70,11 +89,11 @@ msgstr ""
 msgid "User has not the permissions."
 msgstr "Benutzer hat nicht die erforderliche Berechtigung."
 
-#: invenio_records_marc21/resources/serializers/ui/fields/metadata.py:223
+#: invenio_records_marc21/resources/serializers/ui/fields/metadata.py:225
 msgid "Masterthesis"
 msgstr "Masterarbeit"
 
-#: invenio_records_marc21/resources/serializers/ui/fields/metadata.py:224
+#: invenio_records_marc21/resources/serializers/ui/fields/metadata.py:226
 #, fuzzy
 msgid "Dissertation"
 msgstr "Dissertation"
@@ -90,14 +109,16 @@ msgid "Published"
 msgstr "Veröffentlicht"
 
 #: invenio_records_marc21/services/facets.py:20
-msgid "Unpublished"
+#, fuzzy
+#| msgid "Unpublished"
+msgid "Not published"
 msgstr "Unveröffentlicht"
 
 #: invenio_records_marc21/services/facets.py:26
 msgid "File type"
 msgstr "Datei-Typ"
 
-#: invenio_records_marc21/services/schemas/__init__.py:34
+#: invenio_records_marc21/services/schemas/__init__.py:35
 msgid "Invalid persistent identifier scheme."
 msgstr "Ungültiges Schema für permanente Kennung."
 
@@ -126,19 +147,19 @@ msgstr "Zurück zu den Details"
 msgid "Jump up"
 msgstr "Zum Seitenbeginn"
 
-#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:32
+#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:39
 msgid "Published date"
 msgstr "Veröffentlichungsdatum"
 
-#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:33
+#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:40
 msgid "Published in"
 msgstr "Veröffentlicht im"
 
-#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:42
+#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:49
 msgid "Resource type"
 msgstr "Ressource-Typ"
 
-#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:46
+#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:53
 msgid "Access status"
 msgstr "Zugriffsstatus"
 
@@ -204,6 +225,16 @@ msgstr "Erstellt:"
 msgid "Modified:"
 msgstr "Bearbeitet:"
 
+#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/helpers/statistics.html:18
+msgid "Views"
+msgstr ""
+
+#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/helpers/statistics.html:28
+#, fuzzy
+#| msgid "Download"
+msgid "Downloads"
+msgstr "Herunterladen"
+
 #: invenio_records_marc21/templates/invenio_records_marc21/landing_page/macros/detail.html:34
 #: invenio_records_marc21/templates/invenio_records_marc21/landing_page/macros/files.html:51
 msgid "Name"
@@ -258,8 +289,10 @@ msgid "Download"
 msgstr "Herunterladen"
 
 #: invenio_records_marc21/templates/invenio_records_marc21/user_dashboard/uploads.html:7
-msgid "Uploads"
-msgstr "Upload"
+#, fuzzy
+#| msgid "Publications"
+msgid "Publication Uploads"
+msgstr "Publikationen"
 
 #: invenio_records_marc21/ui/records/wrappers.py:16
 msgid "Author"
@@ -289,15 +322,9 @@ msgstr "ErstellerInnen"
 msgid "Curator"
 msgstr "Kurator"
 
-#: invenio_records_marc21/ui/theme/__init__.py:41
+#: invenio_records_marc21/ui/theme/__init__.py:48
 msgid "Publications"
 msgstr "Publikationen"
 
-#: tests/services/schemas/access/test_record.py:45
-msgid "'record' must be either 'public' or 'restricted'"
-msgstr "'Eintrag' muss entweder 'Öffentlich' oder 'Eingeschränkt' sein."
-
-#: tests/services/schemas/access/test_record.py:57
-msgid "'files' must be either 'public' or 'restricted'"
-msgstr "'Datei' muss entweder 'Öffentlich' oder 'Eingeschränkt' sein."
-
+#~ msgid "Uploads"
+#~ msgstr "Upload"

--- a/invenio_records_marc21/translations/en/LC_MESSAGES/messages.po
+++ b/invenio_records_marc21/translations/en/LC_MESSAGES/messages.po
@@ -8,46 +8,63 @@ msgid ""
 msgstr ""
 "Project-Id-Version: invenio-records-marc21 0.2.1\n"
 "Report-Msgid-Bugs-To: info@tugraz.at\n"
-"POT-Creation-Date: 2023-10-03 14:25+0200\n"
-"PO-Revision-Date: 2021-11-11 11:14+0100\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language: en\n"
+"POT-Creation-Date: 2024-05-19 10:39+0200\n"
+"PO-Revision-Date: 2024-05-19 10:40+0200\n"
+"Last-Translator: \n"
 "Language-Team: en <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.12.1\n"
+"X-Generator: Poedit 2.3.1\n"
 
-#: invenio_records_marc21/config.py:49
+#: invenio_records_marc21/config.py:179 invenio_records_marc21/config.py:186
+#: invenio_records_marc21/config.py:201 invenio_records_marc21/config.py:209
+#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/macros/doi.html:24
+#: tests/conftest.py:441 tests/conftest.py:448
+msgid "DOI"
+msgstr ""
+
+#: tests/services/schemas/access/test_record.py:45
+msgid "'record' must be either 'public' or 'restricted'"
+msgstr ""
+
+#: tests/services/schemas/access/test_record.py:57
+msgid "'files' must be either 'public' or 'restricted'"
+msgstr ""
+
+#: invenio_records_marc21/config.py:54
 msgid "Best match"
 msgstr ""
 
-#: invenio_records_marc21/config.py:53
+#: invenio_records_marc21/config.py:58
 msgid "Newest"
 msgstr ""
 
-#: invenio_records_marc21/config.py:57
+#: invenio_records_marc21/config.py:62
 msgid "Oldest"
 msgstr ""
 
-#: invenio_records_marc21/config.py:61
+#: invenio_records_marc21/config.py:66
 msgid "Version"
 msgstr ""
 
-#: invenio_records_marc21/config.py:65
+#: invenio_records_marc21/config.py:70
 msgid "Recently updated"
 msgstr ""
 
-#: invenio_records_marc21/config.py:69
+#: invenio_records_marc21/config.py:74
 msgid "Least recently updated"
 msgstr ""
 
-#: invenio_records_marc21/config.py:170 invenio_records_marc21/config.py:177
-#: invenio_records_marc21/config.py:192 invenio_records_marc21/config.py:200
-#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/macros/doi.html:24
-#: tests/conftest.py:438 tests/conftest.py:445
-msgid "DOI"
+#: invenio_records_marc21/config.py:78
+msgid "Most viewed"
+msgstr ""
+
+#: invenio_records_marc21/config.py:81
+msgid "Most downloaded"
 msgstr ""
 
 #: invenio_records_marc21/errors.py:46
@@ -69,11 +86,11 @@ msgstr ""
 msgid "User has not the permissions."
 msgstr ""
 
-#: invenio_records_marc21/resources/serializers/ui/fields/metadata.py:223
+#: invenio_records_marc21/resources/serializers/ui/fields/metadata.py:225
 msgid "Masterthesis"
 msgstr ""
 
-#: invenio_records_marc21/resources/serializers/ui/fields/metadata.py:224
+#: invenio_records_marc21/resources/serializers/ui/fields/metadata.py:226
 msgid "Dissertation"
 msgstr ""
 
@@ -87,14 +104,14 @@ msgid "Published"
 msgstr ""
 
 #: invenio_records_marc21/services/facets.py:20
-msgid "Unpublished"
+msgid "Not published"
 msgstr ""
 
 #: invenio_records_marc21/services/facets.py:26
 msgid "File type"
 msgstr ""
 
-#: invenio_records_marc21/services/schemas/__init__.py:34
+#: invenio_records_marc21/services/schemas/__init__.py:35
 msgid "Invalid persistent identifier scheme."
 msgstr ""
 
@@ -123,19 +140,19 @@ msgstr ""
 msgid "Jump up"
 msgstr ""
 
-#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:32
+#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:39
 msgid "Published date"
 msgstr ""
 
-#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:33
+#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:40
 msgid "Published in"
 msgstr ""
 
-#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:42
+#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:49
 msgid "Resource type"
 msgstr ""
 
-#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:46
+#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:53
 msgid "Access status"
 msgstr ""
 
@@ -201,6 +218,14 @@ msgstr ""
 msgid "Modified:"
 msgstr ""
 
+#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/helpers/statistics.html:18
+msgid "Views"
+msgstr ""
+
+#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/helpers/statistics.html:28
+msgid "Downloads"
+msgstr ""
+
 #: invenio_records_marc21/templates/invenio_records_marc21/landing_page/macros/detail.html:34
 #: invenio_records_marc21/templates/invenio_records_marc21/landing_page/macros/files.html:51
 msgid "Name"
@@ -253,7 +278,7 @@ msgid "Download"
 msgstr ""
 
 #: invenio_records_marc21/templates/invenio_records_marc21/user_dashboard/uploads.html:7
-msgid "Uploads"
+msgid "Publication Uploads"
 msgstr ""
 
 #: invenio_records_marc21/ui/records/wrappers.py:16
@@ -284,15 +309,6 @@ msgstr ""
 msgid "Curator"
 msgstr ""
 
-#: invenio_records_marc21/ui/theme/__init__.py:41
+#: invenio_records_marc21/ui/theme/__init__.py:48
 msgid "Publications"
 msgstr ""
-
-#: tests/services/schemas/access/test_record.py:45
-msgid "'record' must be either 'public' or 'restricted'"
-msgstr ""
-
-#: tests/services/schemas/access/test_record.py:57
-msgid "'files' must be either 'public' or 'restricted'"
-msgstr ""
-

--- a/invenio_records_marc21/translations/messages.pot
+++ b/invenio_records_marc21/translations/messages.pot
@@ -1,52 +1,68 @@
 # Translations template for invenio-records-marc21.
-# Copyright (C) 2023 Graz University of Technology
+# Copyright (C) 2024 Graz University of Technology
 # This file is distributed under the same license as the
 # invenio-records-marc21 project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: invenio-records-marc21 0.16.1\n"
+"Project-Id-Version: invenio-records-marc21 0.21.0\n"
 "Report-Msgid-Bugs-To: info@tugraz.at\n"
-"POT-Creation-Date: 2023-10-03 14:25+0200\n"
+"POT-Creation-Date: 2024-05-19 10:39+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.12.1\n"
+"Generated-By: Babel 2.14.0\n"
 
-#: invenio_records_marc21/config.py:49
+#: invenio_records_marc21/config.py:179 invenio_records_marc21/config.py:186
+#: invenio_records_marc21/config.py:201 invenio_records_marc21/config.py:209
+#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/macros/doi.html:24
+#: tests/conftest.py:441 tests/conftest.py:448
+msgid "DOI"
+msgstr ""
+
+#: tests/services/schemas/access/test_record.py:45
+msgid "'record' must be either 'public' or 'restricted'"
+msgstr ""
+
+#: tests/services/schemas/access/test_record.py:57
+msgid "'files' must be either 'public' or 'restricted'"
+msgstr ""
+
+#: invenio_records_marc21/config.py:54
 msgid "Best match"
 msgstr ""
 
-#: invenio_records_marc21/config.py:53
+#: invenio_records_marc21/config.py:58
 msgid "Newest"
 msgstr ""
 
-#: invenio_records_marc21/config.py:57
+#: invenio_records_marc21/config.py:62
 msgid "Oldest"
 msgstr ""
 
-#: invenio_records_marc21/config.py:61
+#: invenio_records_marc21/config.py:66
 msgid "Version"
 msgstr ""
 
-#: invenio_records_marc21/config.py:65
+#: invenio_records_marc21/config.py:70
 msgid "Recently updated"
 msgstr ""
 
-#: invenio_records_marc21/config.py:69
+#: invenio_records_marc21/config.py:74
 msgid "Least recently updated"
 msgstr ""
 
-#: invenio_records_marc21/config.py:170 invenio_records_marc21/config.py:177
-#: invenio_records_marc21/config.py:192 invenio_records_marc21/config.py:200
-#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/macros/doi.html:24
-#: tests/conftest.py:438 tests/conftest.py:445
-msgid "DOI"
+#: invenio_records_marc21/config.py:78
+msgid "Most viewed"
+msgstr ""
+
+#: invenio_records_marc21/config.py:81
+msgid "Most downloaded"
 msgstr ""
 
 #: invenio_records_marc21/errors.py:46
@@ -68,11 +84,11 @@ msgstr ""
 msgid "User has not the permissions."
 msgstr ""
 
-#: invenio_records_marc21/resources/serializers/ui/fields/metadata.py:223
+#: invenio_records_marc21/resources/serializers/ui/fields/metadata.py:225
 msgid "Masterthesis"
 msgstr ""
 
-#: invenio_records_marc21/resources/serializers/ui/fields/metadata.py:224
+#: invenio_records_marc21/resources/serializers/ui/fields/metadata.py:226
 msgid "Dissertation"
 msgstr ""
 
@@ -86,14 +102,14 @@ msgid "Published"
 msgstr ""
 
 #: invenio_records_marc21/services/facets.py:20
-msgid "Unpublished"
+msgid "Not published"
 msgstr ""
 
 #: invenio_records_marc21/services/facets.py:26
 msgid "File type"
 msgstr ""
 
-#: invenio_records_marc21/services/schemas/__init__.py:34
+#: invenio_records_marc21/services/schemas/__init__.py:35
 msgid "Invalid persistent identifier scheme."
 msgstr ""
 
@@ -122,19 +138,19 @@ msgstr ""
 msgid "Jump up"
 msgstr ""
 
-#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:32
+#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:39
 msgid "Published date"
 msgstr ""
 
-#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:33
+#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:40
 msgid "Published in"
 msgstr ""
 
-#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:42
+#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:49
 msgid "Resource type"
 msgstr ""
 
-#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:46
+#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/record.html:53
 msgid "Access status"
 msgstr ""
 
@@ -200,6 +216,14 @@ msgstr ""
 msgid "Modified:"
 msgstr ""
 
+#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/helpers/statistics.html:18
+msgid "Views"
+msgstr ""
+
+#: invenio_records_marc21/templates/invenio_records_marc21/landing_page/helpers/statistics.html:28
+msgid "Downloads"
+msgstr ""
+
 #: invenio_records_marc21/templates/invenio_records_marc21/landing_page/macros/detail.html:34
 #: invenio_records_marc21/templates/invenio_records_marc21/landing_page/macros/files.html:51
 msgid "Name"
@@ -252,7 +276,7 @@ msgid "Download"
 msgstr ""
 
 #: invenio_records_marc21/templates/invenio_records_marc21/user_dashboard/uploads.html:7
-msgid "Uploads"
+msgid "Publication Uploads"
 msgstr ""
 
 #: invenio_records_marc21/ui/records/wrappers.py:16
@@ -283,15 +307,7 @@ msgstr ""
 msgid "Curator"
 msgstr ""
 
-#: invenio_records_marc21/ui/theme/__init__.py:41
+#: invenio_records_marc21/ui/theme/__init__.py:48
 msgid "Publications"
-msgstr ""
-
-#: tests/services/schemas/access/test_record.py:45
-msgid "'record' must be either 'public' or 'restricted'"
-msgstr ""
-
-#: tests/services/schemas/access/test_record.py:57
-msgid "'files' must be either 'public' or 'restricted'"
 msgstr ""
 


### PR DESCRIPTION
* it was not only the reason of the wording but also the problem with
  the ordering of the translation imports. since the packages are used
  after the my-site/translations the overrides there didn't worked
  anymore. therefore the change here makes the override in
  my-site/translations work again
