### PR TITLE
Optimize OpenSearch Index by Indexing Only Static Metadata Fields

### DIFF
--- a/invenio_records_marc21/records/mappings/os-v2/marc21records/drafts/marc21-v2.0.0.json
+++ b/invenio_records_marc21/records/mappings/os-v2/marc21records/drafts/marc21-v2.0.0.json
@@ -52,16 +52,6 @@
             }
           }
         }
-      },
-      {
-        "metadata_field": {
-          "path_match": "metadata.fields.*",
-          "match_mapping_type": "object",
-          "mapping": {
-            "index": false,
-            "type": "object"
-          }
-        }
       }
     ],
     "date_detection": false,
@@ -244,6 +234,7 @@
         "type": "boolean"
       },
       "metadata": {
+        "dynamic": false,
         "properties": {
           "fields": {
             "properties": {

--- a/invenio_records_marc21/records/mappings/os-v2/marc21records/marc21/marc21-v2.0.0.json
+++ b/invenio_records_marc21/records/mappings/os-v2/marc21records/marc21/marc21-v2.0.0.json
@@ -52,16 +52,6 @@
             }
           }
         }
-      },
-      {
-        "metadata_field": {
-          "path_match": "metadata.fields.*",
-          "match_mapping_type": "object",
-          "mapping": {
-            "index": false,
-            "type": "object"
-          }
-        }
       }
     ],
     "date_detection": false,
@@ -244,6 +234,7 @@
         "type": "boolean"
       },
       "metadata": {
+        "dynamic": false,
         "properties": {
           "fields": {
             "properties": {


### PR DESCRIPTION
# Summary

This pull request introduces an optimization to our OpenSearch indexing process by ensuring that only static metadata fields are indexed. This change aims to improve search performance, reduce storage requirements, and streamline the indexing process by excluding dynamic fields that do not contribute to search relevancy.

# Background

Previously, our OpenSearch index included both static and dynamic metadata fields. Dynamic fields, while useful for data representation, do not play a significant role in search queries. Indexing these fields unnecessarily increases the index size and impacts search performance.

# Changes

Modified the OpenSearch mapping configuration to set dynamic to false for the metadata object. This prevents automatic indexing of any new fields not explicitly defined in the mapping.

# Additional Steps

Recreate OpenSearch Index: The OpenSearch index must be recreated to apply the changes effectively. 