### PR TITLE
Enable Resource Type facet in search

### DIFF
--- a/invenio_records_marc21/config.py
+++ b/invenio_records_marc21/config.py
@@ -41,6 +41,12 @@ MARC21_FACETS = {
             "field": "is_published",
         },
     },
+    "resource_type": {
+        "facet": facets.resource_type,
+        "ui": {
+            "field": "metadata.resource_type",
+        },
+    },
     "file_type": {
         "facet": facets.filetype,
         "ui": {
@@ -83,7 +89,11 @@ MARC21_SORT_OPTIONS = {
 }
 
 MARC21_SEARCH_DRAFTS = {
-    "facets": ["access_status", "is_published", "file_type"],
+    "facets": [
+        "resource_type",
+        "access_status",
+        "is_published",
+    ],
     "sort": [
         "bestmatch",
         "newest",
@@ -94,7 +104,10 @@ MARC21_SEARCH_DRAFTS = {
 """User records search configuration (i.e. list of uploads)."""
 
 MARC21_SEARCH = {
-    "facets": ["access_status", "file_type"],
+    "facets": [
+        "resource_type",
+        "access_status",
+    ],
     "sort": [
         "bestmatch",
         "newest",

--- a/invenio_records_marc21/records/api.py
+++ b/invenio_records_marc21/records/api.py
@@ -16,7 +16,6 @@ from invenio_drafts_resources.records import Draft, Record
 from invenio_drafts_resources.records.api import ParentRecord as BaseParentRecord
 from invenio_drafts_resources.records.systemfields import ParentField
 from invenio_pidstore.models import PIDStatus
-from invenio_rdm_records.records.dumpers import StatisticsDumperExt
 from invenio_rdm_records.records.systemfields import (
     HasDraftCheckField,
     ParentRecordAccessField,

--- a/invenio_records_marc21/services/config.py
+++ b/invenio_records_marc21/services/config.py
@@ -92,9 +92,6 @@ class Marc21RecordServiceConfig(RecordServiceConfig, ConfiguratorMixin):
     schema_secret_link = None
     review = None
 
-    # Permission policy
-    default_files_enabled = FromConfig("RDM_DEFAULT_FILES_ENABLED", default=True)
-
     permission_policy_cls = FromConfig(
         "MARC21_PERMISSION_POLICY",
         default=Marc21RecordPermissionPolicy,

--- a/invenio_records_marc21/services/config.py
+++ b/invenio_records_marc21/services/config.py
@@ -52,6 +52,7 @@ class Marc21SearchOptions(SearchOptions, SearchOptionsMixin):
 
     facets = {
         "access_status": rdm_facets.access_status,
+        "resource_type": facets.resource_type,
     }
 
 
@@ -61,6 +62,7 @@ class Marc21SearchDraftsOptions(SearchDraftsOptions, SearchOptionsMixin):
     facets = {
         "access_status": rdm_facets.access_status,
         "is_published": facets.is_published,
+        "resource_type": facets.resource_type,
     }
 
 

--- a/invenio_records_marc21/services/facets.py
+++ b/invenio_records_marc21/services/facets.py
@@ -14,6 +14,8 @@
 from invenio_i18n import gettext as _
 from invenio_records_resources.services.records.facets import TermsFacet
 
+from ..records.fields.resourcetype import ResourceTypeEnum
+
 is_published = TermsFacet(
     field="is_published",
     label=_("Status"),
@@ -25,4 +27,14 @@ filetype = TermsFacet(
     field="files.types",
     label=_("File type"),
     value_labels=lambda ids: {id: id.upper() for id in ids},
+)
+
+
+resource_type = TermsFacet(
+    field="metadata.fields.970.subfields.d",
+    label=_("Resource type"),
+    value_labels={
+        ResourceTypeEnum.HSMASTER.value: _("Masterthesis"),
+        ResourceTypeEnum.HSDISS.value: _("Dissertation"),
+    },
 )


### PR DESCRIPTION
# Summary

This pull request introduces functionality to allow users to filter records by resource type. This enhancement aims to improve the usability and efficiency of our search capabilities, enabling users to filter records more precisely based on the type of resource they are interested in.

# Background

The ability to filter by resource type has been a frequently requested feature from our user community. Previously, users could only filter records based on access type. This limitation made it challenging for users to narrow down search results to specific types of resources.

# Changes

- Facet Update: The resource_type field is alredy indexed and searchable, allowing it to be used as a filter in search queries.
- Search API Enhancement: Modified the search API to accept resource_type as a facet parameter. Users can now specify one or more resource types to filter their search results.
- User Interface Update: Added a new filter option in the search interface for resource type. Users can select from a predefined list of resource types, or type in the resource type to filter their search results.

# Benefits

- Improved Search Precision: Users can now easily find resources of a specific type, enhancing the overall search experience.
- Increased Usability: The addition of resource type filtering makes the search functionality more intuitive and user-friendly.
Enhanced Data Organization: By categorizing records by resource type, we can offer more structured and organized search results.


# Demo
![image](https://github.com/tu-graz-library/invenio-records-marc21/assets/17226159/da1180cc-fd0e-4748-a5eb-92381797c8b1)
