### PR TITLE
fix(deposit): page render and save a empty record

### DIFF
--- a/invenio_records_marc21/resources/deserializers/schema.py
+++ b/invenio_records_marc21/resources/deserializers/schema.py
@@ -31,6 +31,12 @@ class Marc21Schema(Schema):
     def load_metadata(self, value):
         """Load metadata."""
         fields = {}
+        metadata = {
+            "leader": value["leader"],
+        }
+
+        if "fields" not in value:
+            return metadata
 
         for field in value["fields"]:
             if int(field["id"]) < 10:
@@ -50,10 +56,8 @@ class Marc21Schema(Schema):
                         "subfields": subfields,
                     }
                 )
-        return {
-            "fields": fields,
-            "leader": value["leader"],
-        }
+        metadata["fields"] = fields
+        return metadata
 
     @pre_load
     def remove(self, data, **kwargs):

--- a/invenio_records_marc21/resources/serializers/deposit/schema.py
+++ b/invenio_records_marc21/resources/serializers/deposit/schema.py
@@ -20,8 +20,14 @@ class MetadataDepositField(Field):
 
     def _serialize(self, value, attr, obj, **kwargs):
         """Serialize metadata field."""
-        fields_ui = []
+        record = {
+            "fields": [],
+            "leader": value.get("leader"),
+        }
+        if "fields" not in value:
+            return record
 
+        fields_ui = []
         for category, fields in value["fields"].items():
             if isinstance(fields, str):
                 obj = {
@@ -45,11 +51,8 @@ class MetadataDepositField(Field):
                     }
 
                     fields_ui.append(obj)
-
-        return {
-            "fields": fields_ui,
-            "leader": value.get("leader"),
-        }
+        record["fields"] = fields_ui
+        return record
 
 
 class Marc21DepositSchema(Marc21Schema):

--- a/invenio_records_marc21/ui/theme/deposit.py
+++ b/invenio_records_marc21/ui/theme/deposit.py
@@ -20,7 +20,7 @@ from ...proxies import current_records_marc21
 def empty_record():
     """Create an empty record."""
     record = dump_empty(Marc21RecordSchema)
-    record["metadata"] = "<record><leader>00000nam a2200000zca4500</leader></record>"
+    record["metadata"] = {"leader": "00000nam a2200000zca4500", "fields": []}
     record["access"] = {"record": "public", "files": "public"}
     record["files"] = {"enabled": True}
     record["status"] = "draft"


### PR DESCRIPTION
# Problem

The metadata structure for deposit has changed, but the backend is still sending the previous format, which lacks the fields key. This causes serialization errors and results in empty records being saved, as the backend attempts to process incomplete metadata.

# Solution

This fix updates the serializer to handle cases where the fields key is missing from the metadata. By marking fields as optional, the serializer can now handle responses from the backend that omit this key, preventing the creation and saving of empty records.