### PR TITLE
feat: imp file access permissions for MARC21 records

### DIFF
--- a/invenio_records_marc21/ui/records/__init__.py
+++ b/invenio_records_marc21/ui/records/__init__.py
@@ -11,7 +11,10 @@
 """Records user interface."""
 
 from invenio_pidstore.errors import PIDDeletedError, PIDDoesNotExistError
-from invenio_records_resources.services.errors import PermissionDeniedError
+from invenio_records_resources.services.errors import (
+    PermissionDeniedError,
+    RecordPermissionDeniedError,
+)
 
 from .errors import (
     not_found_error,
@@ -56,8 +59,12 @@ def init_records_views(blueprint, app):
     blueprint.register_error_handler(PIDDeletedError, record_tombstone_error)
     blueprint.register_error_handler(PIDDoesNotExistError, not_found_error)
     blueprint.register_error_handler(KeyError, not_found_error)
+
     blueprint.register_error_handler(
         PermissionDeniedError, record_permission_denied_error
+    )
+    blueprint.register_error_handler(
+        RecordPermissionDeniedError, record_permission_denied_error
     )
 
     # Register template filters


### PR DESCRIPTION
 The handler renders the permission denied template with a 403 status code when a user attempts to access a resource they don't have permission for.
 
-  added record_permission_denied_error function to errors.py
- the handler returns the  template with a 403 status code

![Screenshot From 2025-05-15 16-33-48](https://github.com/user-attachments/assets/624e928d-dd7c-4afb-994a-b3004eeb6086)
![Screenshot From 2025-05-15 16-34-11](https://github.com/user-attachments/assets/98b56cea-f7cb-4bb0-b5c4-f7af46bc8b6f)

### Previous State (Before Changes)
- Anonymous user: for restricted files: wrong login prompt
- Authenticalted user: restricted files not checked


