### PR TITLE
alembic: prevent dropping of already dropped index

### DIFF
--- a/invenio_records_marc21/alembic/0058aec64e36_create_marc21_tables.py
+++ b/invenio_records_marc21/alembic/0058aec64e36_create_marc21_tables.py
@@ -299,7 +299,15 @@ def upgrade():
         table_name="records_metadata_version",
     )
     op.drop_table("records_metadata_version")
-    op.drop_index("ix_uq_partial_files_object_is_head", table_name="files_object")
+
+    # the following index is dropped in multiple upgrade-scripts, guard in case this drop isn't the first
+    metadata = sa.MetaData()
+    files_object_table = sa.Table("files_object", metadata, autoload_with=op.get_bind())
+    if "ix_uq_partial_files_object_is_head" in [
+        index.name for index in files_object_table.indexes
+    ]:
+        op.drop_index("ix_uq_partial_files_object_is_head", table_name="files_object")
+
     # ### end Alembic commands ###
 
 


### PR DESCRIPTION
index `ix_uq_partial_files_object_is_head` is dropped by invenio thrice but created only once
in case our upgrade-script isn't the first to drop it, the drop fails
this commit prevents drop-attempts when index is already dropped

this copies the fix from `invenio_files_rest`, where the same issue was encountered: see [here](https://github.com/inveniosoftware/invenio-files-rest/blob/5ab80323165b2aa155344d2c8b9123365ca216a4/invenio_files_rest/alembic/e172c837b036_add_indexes.py#L25)