### PR TITLE
Make the publication uploads dashboard overridable

### DIFF
--- a/invenio_records_marc21/config.py
+++ b/invenio_records_marc21/config.py
@@ -121,6 +121,9 @@ MARC21_SEARCH = {
 
 MARC21_BASE_TEMPLATE = "invenio_records_marc21/base.html"
 
+MARC21_UPLOADS_TEMPLATE = "invenio_records_marc21/user_dashboard/uploads.html"
+"""Template for the user's publication uploads dashboard."""
+
 MARC21_SEARCH_NAV_TEMPLATE = None
 """Template injected above the marc21 search app.
 

--- a/invenio_records_marc21/ext.py
+++ b/invenio_records_marc21/ext.py
@@ -73,7 +73,7 @@ class InvenioRecordsMARC21:
                     case dict() as container:
                         container.update(attr)
                     case _:
-                        app.config[configuration_variable] = attr
+                        app.config.setdefault(configuration_variable, attr)
 
             elif bool(pattern.match(configuration_variable)):
                 match attr:

--- a/invenio_records_marc21/services/links.py
+++ b/invenio_records_marc21/services/links.py
@@ -63,6 +63,7 @@ DefaultServiceLinks = {
         if_=RecordEndpointLink("marc21_record_files.search"),
         else_=RecordEndpointLink("marc21_draft_files.search"),
     ),
-    "draft": RecordEndpointLink("marc21_records.read_draft", when=is_record),
+    "draft": RecordEndpointLink("invenio_records_marc21.deposit_edit", when=is_record),
+    "edit": RecordEndpointLink("marc21_records.edit"),
     "publish": RecordEndpointLink("marc21_records.publish", when=is_draft),
 }

--- a/invenio_records_marc21/templates/invenio_records_marc21/user_dashboard/uploads.html
+++ b/invenio_records_marc21/templates/invenio_records_marc21/user_dashboard/uploads.html
@@ -1,5 +1,5 @@
 {#
-Copyright (C) 2023 Graz University of Technology
+Copyright (C) 2023-2026 Graz University of Technology
 
 invenio-records-marc21 is free software; you can redistribute it and/or modify
 it under the terms of the MIT License; see LICENSE file for more details.
@@ -19,15 +19,17 @@ it under the terms of the MIT License; see LICENSE file for more details.
     {% include "invenio_app_rdm/users/header.html" %}
   {%- endblock user_dashboard_header %}
 
-  <div class="ui container rel-mt-2">
-    <a class="ui tiny button positive right floated labeled icon m-0" href="/publications/uploads/new" style="margin-top: 18px !important">
-      <i class="upload icon" aria-hidden="true"></i>
-      {{ _('New upload') }}
-    </a>
-  </div>
+  {%- block dashboard_actions %}
+    <div class="ui container rel-mt-2">
+      <a class="ui tiny button positive right floated labeled icon m-0" href="/publications/uploads/new" style="margin-top: 18px !important">
+        <i class="upload icon" aria-hidden="true"></i>
+        {{ _('New upload') }}
+      </a>
+    </div>
+  {%- endblock dashboard_actions %}
 
   <div class="ui container rel-mt-2">
-    <div id="invenio-search-marc21-config" data-invenio-search-config='{{ search_app_marc21_user_uploads_config() | tojson }}'>
+    <div id="invenio-search-marc21-config" class="uploads-search-app" data-invenio-search-config='{{ search_app_marc21_user_uploads_config() | tojson }}'>
     </div>
   </div>
 {%- endblock page_body %}

--- a/invenio_records_marc21/ui/theme/views.py
+++ b/invenio_records_marc21/ui/theme/views.py
@@ -10,7 +10,7 @@
 
 """Routes for general pages provided by Invenio-Records-Marc21."""
 
-from flask import g, render_template
+from flask import current_app, g, render_template
 from flask_login import current_user, login_required
 from invenio_users_resources.proxies import current_user_resources
 
@@ -41,7 +41,7 @@ def uploads_marc21() -> str:
     )["avatar"]
 
     return render_template(
-        "invenio_records_marc21/user_dashboard/uploads.html",
+        current_app.config["MARC21_UPLOADS_TEMPLATE"],
         user_avatar=url,
     )
 


### PR DESCRIPTION
The publication uploads dashboard is rendered from a hardcoded template path. A deployment that wants to customise it add adifferent upload action, set a page description, adjust the layout has no clean way in: the only option is to drop a full copy of the template into the instance. That copy loses the Jinja path collision to the packages own template, breaks whenever the upstream template changes, and can't be shared as a reusable override.
 
This PR makes the dashboard overridable the same way the rest of marc21's templates are. It adds a MARC21_UPLOADS_TEMPLATE config defaulting to the current template, so behaviour is unchanged out of the box and the view now renders whatever that config points at. The default template wraps its upload action in a dashboard actions block, so a downstream template can extend it and override only that block instead of copying the whole file. The search app is also tagged with the standard uploads-search-app marker class so deployments can style the dashboard search row consistently.

Same approach i would apply for LOM. 

Note:
Solved the edit button on the publication uploads dashboard, clicking Edit which does nothing it sends a request to /publications/undefined and fails, so published records can not be edited from the dashboard.

The cause is in the search result item: the Edit button reads links["edit"], but that link key doesn't exist in the record's links the record only exposes self, self_html, files, and draft. So the button's POST target is undefined, and it errors out as the single link prop to separate linkLocation / linkEdit props, where linkEdit was pointed at the non-existent edit link. After this fix i was able locally to open the Edit button. 

#### screenshot 
<img width="1322" height="681" alt="Screenshot 2026-06-02 at 09 13 26" src="https://github.com/user-attachments/assets/a774e730-025c-45e1-a81e-30a52a6c1dd5" />
<img width="1001" height="520" alt="Screenshot 2026-06-02 at 09 58 49" src="https://github.com/user-attachments/assets/5a3da182-6bdf-4bc6-a647-690d6412e9ae" />
